### PR TITLE
Update theme to red and add registration form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const AppContent = () => {
 
   if (loading) {
     return (
-      <div className="h-screen flex items-center justify-center bg-blue-900">
+      <div className="h-screen flex items-center justify-center bg-red-900">
         <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-cyan-500"></div>
       </div>
     );

--- a/src/components/Auth/AuthLayout.tsx
+++ b/src/components/Auth/AuthLayout.tsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { useAppContext } from '../../context/AppContext';
 
 const AuthLayout: React.FC = () => {
-  const { signIn } = useAppContext();
+  const { signIn, signUp } = useAppContext();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [isRegister, setIsRegister] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -14,20 +15,25 @@ const AuthLayout: React.FC = () => {
     setLoading(true);
 
     try {
-      await signIn(email, password);
-    } catch (err: any) {
-      setError(err.message || 'An error occurred during sign in');
+      if (isRegister) {
+        await signUp(email, password);
+      } else {
+        await signIn(email, password);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred';
+      setError(message);
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="min-h-screen bg-blue-900 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-red-900 flex items-center justify-center p-4">
       <div className="max-w-md w-full space-y-8 bg-slate-800 p-8 rounded-lg">
         <div>
           <h2 className="text-center text-3xl font-bold text-white">
-            Войти в Chrono
+            {isRegister ? 'Регистрация в Chrono' : 'Войти в Chrono'}
           </h2>
           <p className="mt-2 text-center text-sm text-slate-400">
             Контент по расписанию
@@ -85,11 +91,36 @@ const AuthLayout: React.FC = () => {
               {loading ? (
                 <div className="w-5 h-5 border-t-2 border-white rounded-full animate-spin"></div>
               ) : (
-                'Войти'
+                isRegister ? 'Зарегистрироваться' : 'Войти'
               )}
-            </button>
-          </div>
-        </form>
+          </button>
+        </div>
+        <div className="text-center">
+          {isRegister ? (
+            <p className="text-sm text-slate-400">
+              Уже есть аккаунт?{' '}
+              <button
+                type="button"
+                className="text-cyan-500 hover:underline"
+                onClick={() => setIsRegister(false)}
+              >
+                Войти
+              </button>
+            </p>
+          ) : (
+            <p className="text-sm text-slate-400">
+              Нет аккаунта?{' '}
+              <button
+                type="button"
+                className="text-cyan-500 hover:underline"
+                onClick={() => setIsRegister(true)}
+              >
+                Зарегистрироваться
+              </button>
+            </p>
+          )}
+        </div>
+      </form>
       </div>
     </div>
   );

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -25,7 +25,7 @@ const AppLayout: React.FC = () => {
   };
 
   return (
-    <div className="flex h-screen bg-blue-900 text-white">
+    <div className="flex h-screen bg-red-900 text-white">
       <Sidebar />
       <main className="flex-1 overflow-y-auto">
         {renderCurrentView()}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -24,6 +24,7 @@ interface AppContextType {
   updatePost: (postId: string, updates: Partial<Post>) => Promise<void>;
   deletePost: (postId: string) => Promise<void>;
   signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
   clearError: () => void;
 }
@@ -208,6 +209,21 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     }
   };
 
+  const signUp = async (email: string, password: string) => {
+    try {
+      setError(null);
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+      });
+      if (error) throw error;
+    } catch (err) {
+      const errorMessage = handleSupabaseError(err);
+      setError(errorMessage);
+      throw new Error(errorMessage);
+    }
+  };
+
   const signOut = async () => {
     try {
       setError(null);
@@ -244,6 +260,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         updatePost,
         deletePost,
         signIn,
+        signUp,
         signOut,
         clearError,
       }}

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@
 }
 
 body {
-  @apply bg-blue-900 text-white;
+  @apply bg-red-900 text-white;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 


### PR DESCRIPTION
## Summary
- switch global background color to red
- add user sign-up support in `AppContext`
- implement registration form toggle in `AuthLayout`
- update loading and layout backgrounds

## Testing
- `npm run lint` *(fails: some unused vars & other lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_684163515aac832ebf0344b144c6b60a