### PR TITLE
Preserve local timezone in date formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.39.0",
         "date-fns": "^3.3.1",
+        "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2007,6 +2008,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
     "date-fns": "^3.3.1",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -5,6 +5,7 @@ import { useAppContext } from '../../context/AppContext';
 import { ChevronLeft, ChevronRight, CalendarDays } from 'lucide-react';
 import CalendarDay from './CalendarDay';
 import ClientFilter from './ClientFilter';
+import { formatLocalISO } from '../../utils/time';
 
 const Calendar: React.FC = () => {
   const { clients, posts, setCurrentView, setSelectedDate } = useAppContext();
@@ -27,7 +28,7 @@ const Calendar: React.FC = () => {
   };
 
   const handleAddPost = (date: Date) => {
-    setSelectedDate(date.toISOString());
+    setSelectedDate(formatLocalISO(date));
     setCurrentView('post-editor');
   };
 

--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, Clock, Image, Send, X } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { formatLocalISO } from '../../utils/time';
 
 const PostEditor: React.FC = () => {
   const { 
@@ -31,7 +32,7 @@ const PostEditor: React.FC = () => {
         setPlatforms(post.platforms);
         
         const date = new Date(post.scheduledFor);
-        setScheduledDate(date.toISOString().split('T')[0]);
+        setScheduledDate(formatLocalISO(date).split('T')[0]);
         setScheduledTime(date.toTimeString().slice(0, 5));
       }
     } else if (selectedClient) {
@@ -48,14 +49,14 @@ const PostEditor: React.FC = () => {
     }
     
     if (selectedDate) {
-      setScheduledDate(new Date(selectedDate).toISOString().split('T')[0]);
+      setScheduledDate(formatLocalISO(new Date(selectedDate)).split('T')[0]);
     } else {
-      setScheduledDate(new Date().toISOString().split('T')[0]);
+      setScheduledDate(formatLocalISO(new Date()).split('T')[0]);
     }
   }, [selectedPost, selectedClient, selectedDate, posts, clients]);
   
   const handleSavePost = () => {
-    const scheduledDateTime = new Date(`${scheduledDate}T${scheduledTime}`).toISOString();
+    const scheduledDateTime = formatLocalISO(new Date(`${scheduledDate}T${scheduledTime}`));
     
     if (selectedPost) {
       updatePost(selectedPost, {

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { Client, Post, PostTemplate } from '../types';
 import { supabase, handleSupabaseError } from '../lib/supabase';
+import { formatLocalISO } from '../utils/time';
 import sanitizeHtml from 'sanitize-html';
 import { User } from '@supabase/supabase-js';
 
@@ -131,7 +132,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       setError(null);
       const sanitizedContent = sanitizeHtml(post.content);
-      const now = new Date().toISOString();
+      const now = formatLocalISO(new Date());
       
       const { data, error } = await supabase
         .from('posts')
@@ -159,7 +160,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       if (updates.content) {
         updates.content = sanitizeHtml(updates.content);
       }
-      updates.updatedAt = new Date().toISOString();
+      updates.updatedAt = formatLocalISO(new Date());
 
       const { data, error } = await supabase
         .from('posts')

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -85,7 +85,7 @@ export const mockPosts: Post[] = [
     content: 'Сегодня в нашем кафе новое сезонное меню! Приходите попробовать наши фирменные десерты с тыквой и специями 🍂',
     media: ['https://images.pexels.com/photos/1055272/pexels-photo-1055272.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2'],
     platforms: ['telegram', 'instagram'],
-    scheduledFor: '2025-10-01T12:00:00Z',
+    scheduledFor: '2025-10-01T12:00:00+03:00',
     status: 'scheduled',
     createdAt: '2025-09-25T10:30:00Z',
     updatedAt: '2025-09-25T11:45:00Z'
@@ -96,7 +96,7 @@ export const mockPosts: Post[] = [
     content: 'Новая коллекция уже в магазинах! Используйте промокод URBAN25 для скидки 15% на все товары до конца недели 👕',
     media: ['https://images.pexels.com/photos/5709661/pexels-photo-5709661.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2'],
     platforms: ['vk', 'instagram'],
-    scheduledFor: '2025-10-02T15:00:00Z',
+    scheduledFor: '2025-10-02T15:00:00+03:00',
     status: 'draft',
     createdAt: '2025-09-26T09:15:00Z',
     updatedAt: '2025-09-26T09:15:00Z'
@@ -107,7 +107,7 @@ export const mockPosts: Post[] = [
     content: '5 простых медитаций, которые можно делать прямо на рабочем месте. Сохраняйте, чтобы не потерять 🧘‍♀️',
     media: ['https://images.pexels.com/photos/3560044/pexels-photo-3560044.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2'],
     platforms: ['telegram', 'vk', 'instagram'],
-    scheduledFor: '2025-10-03T08:00:00Z',
+    scheduledFor: '2025-10-03T08:00:00+03:00',
     status: 'scheduled',
     createdAt: '2025-09-27T14:20:00Z',
     updatedAt: '2025-09-27T16:35:00Z'

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,14 @@
+import { formatInTimeZone } from 'date-fns-tz';
+
+/**
+ * Format a Date into an ISO string while keeping the local time zone offset.
+ * We avoid Date.toISOString() here because it converts the date to UTC.
+ * By using `formatInTimeZone` we preserve the given zone (defaults to the
+ * current environment's zone) in the resulting string.
+ */
+export const formatLocalISO = (
+  date: Date,
+  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone
+): string => {
+  return formatInTimeZone(date, timeZone, "yyyy-MM-dd'T'HH:mm:ssXXX");
+};


### PR DESCRIPTION
## Summary
- add `formatLocalISO` utility using `date-fns-tz`
- use helper to store created and updated times
- keep selected date in local zone and save posts with local time
- adjust mock data to include timezone offset

## Testing
- `npm run lint` *(fails: no-unused-vars errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6841693616e0832eacb8f655c64f4169