### PR TITLE
Remove unused icons from ClientsView

### DIFF
--- a/src/components/Clients/ClientsView.tsx
+++ b/src/components/Clients/ClientsView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, Edit, Trash, Link } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import ClientCard from './ClientCard';
 import AddClientModal from './AddClientModal';


### PR DESCRIPTION
## Summary
- remove `Edit`, `Trash` and `Link` icons from `ClientsView` import

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684168c248a0832e937b549042331df5