### PR TITLE
Add client edit & delete handling

### DIFF
--- a/src/components/Clients/ClientCard.tsx
+++ b/src/components/Clients/ClientCard.tsx
@@ -8,11 +8,29 @@ interface ClientCardProps {
 }
 
 const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
-  const { setSelectedClient, setCurrentView } = useAppContext();
+  const {
+    setSelectedClient,
+    setCurrentView,
+    updateClient,
+    deleteClient
+  } = useAppContext();
 
   const handleCreatePost = () => {
     setSelectedClient(client.id);
     setCurrentView('post-editor');
+  };
+
+  const handleEdit = async () => {
+    const newName = window.prompt('Новое название клиента', client.name);
+    if (newName && newName !== client.name) {
+      await updateClient(client.id, { name: newName });
+    }
+  };
+
+  const handleDelete = async () => {
+    if (window.confirm(`Удалить клиента "${client.name}"?`)) {
+      await deleteClient(client.id);
+    }
   };
 
   return (
@@ -69,10 +87,16 @@ const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
           >
             Создать публикацию
           </button>
-          <button className="p-2 rounded bg-slate-700 hover:bg-slate-600 transition-colors">
+          <button
+            onClick={handleEdit}
+            className="p-2 rounded bg-slate-700 hover:bg-slate-600 transition-colors"
+          >
             <Edit size={16} />
           </button>
-          <button className="p-2 rounded bg-slate-700 hover:bg-red-700 transition-colors">
+          <button
+            onClick={handleDelete}
+            className="p-2 rounded bg-slate-700 hover:bg-red-700 transition-colors"
+          >
             <Trash size={16} />
           </button>
         </div>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -21,6 +21,8 @@ interface AppContextType {
   setSelectedDate: (date: string | null) => void;
   setSelectedPost: (postId: string | null) => void;
   addClient: (client: Omit<Client, 'id'>) => Promise<void>;
+  updateClient: (clientId: string, updates: Partial<Client>) => Promise<void>;
+  deleteClient: (clientId: string) => Promise<void>;
   addPost: (post: Omit<Post, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
   updatePost: (postId: string, updates: Partial<Post>) => Promise<void>;
   deletePost: (postId: string) => Promise<void>;
@@ -121,6 +123,42 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       
       if (error) throw error;
       setClients([...clients, data]);
+    } catch (err) {
+      const errorMessage = handleSupabaseError(err);
+      setError(errorMessage);
+      throw new Error(errorMessage);
+    }
+  };
+
+  const updateClient = async (clientId: string, updates: Partial<Client>) => {
+    try {
+      setError(null);
+      const { data, error } = await supabase
+        .from('clients')
+        .update(updates)
+        .eq('id', clientId)
+        .select()
+        .single();
+
+      if (error) throw error;
+      setClients(clients.map(c => (c.id === clientId ? data : c)));
+    } catch (err) {
+      const errorMessage = handleSupabaseError(err);
+      setError(errorMessage);
+      throw new Error(errorMessage);
+    }
+  };
+
+  const deleteClient = async (clientId: string) => {
+    try {
+      setError(null);
+      const { error } = await supabase
+        .from('clients')
+        .delete()
+        .eq('id', clientId);
+
+      if (error) throw error;
+      setClients(clients.filter(c => c.id !== clientId));
     } catch (err) {
       const errorMessage = handleSupabaseError(err);
       setError(errorMessage);
@@ -257,6 +295,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         setSelectedDate,
         setSelectedPost,
         addClient,
+        updateClient,
+        deleteClient,
         addPost,
         updatePost,
         deletePost,


### PR DESCRIPTION
## Summary
- add `updateClient` and `deleteClient` functions in context
- expose new functions through `AppContext`
- wire ClientCard edit and delete buttons to context
- confirm before deleting a client

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684177f567ac832e96efcc35787e36b0