### PR TITLE
Implement image uploads with Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_STORAGE_BUCKET=media

--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@
 
 - `VITE_SUPABASE_URL` — адрес проекта Supabase
 - `VITE_SUPABASE_ANON_KEY` — публичный ключ (Anon Key)
+- `VITE_SUPABASE_STORAGE_BUCKET` — название бакета Storage для загрузки файлов
 
 ## Пример `.env.example`
 
 ```bash
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_STORAGE_BUCKET=media
 ```
 
 ## Database setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.39.0",
+        "browser-image-compression": "^2.0.1",
         "date-fns": "^3.3.1",
         "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.344.0",
@@ -1810,6 +1811,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -4088,6 +4098,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
+    "browser-image-compression": "^2.0.1",
     "date-fns": "^3.3.1",
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.344.0",

--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Calendar, Clock, Image, Send, X } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import { formatLocalISO } from '../../utils/time';
+import imageCompression from 'browser-image-compression';
+import { uploadFile } from '../../lib/storage';
 
 const PostEditor: React.FC = () => {
   const { 
@@ -25,6 +27,7 @@ const PostEditor: React.FC = () => {
   const [scheduledTime, setScheduledTime] = useState('12:00');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
   
   useEffect(() => {
     if (selectedPost) {
@@ -103,6 +106,40 @@ const PostEditor: React.FC = () => {
       setMediaInputError('');
     } catch {
       setMediaInputError('Некорректный URL');
+    }
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    const maxSize = 5 * 1024 * 1024; // 5MB
+
+    if (!allowedTypes.includes(file.type)) {
+      setMediaInputError('Недопустимый тип файла');
+      return;
+    }
+
+    if (file.size > maxSize) {
+      setMediaInputError('Файл превышает 5MB');
+      return;
+    }
+
+    setMediaInputError('');
+    const previewUrl = URL.createObjectURL(file);
+    setMediaUrls(prev => [...prev, previewUrl]);
+
+    try {
+      const compressed = await imageCompression(file, { maxSizeMB: 1, maxWidthOrHeight: 1920, useWebWorker: true });
+      const uploadedUrl = await uploadFile(compressed);
+      setMediaUrls(current => current.map(url => url === previewUrl ? uploadedUrl : url));
+    } catch {
+      setMediaUrls(current => current.filter(url => url !== previewUrl));
+      setMediaInputError('Не удалось загрузить файл');
+    } finally {
+      URL.revokeObjectURL(previewUrl);
+      if (fileInputRef.current) fileInputRef.current.value = '';
     }
   };
   
@@ -200,6 +237,20 @@ const PostEditor: React.FC = () => {
                 >
                   <Image size={14} className="mr-1" />
                   Добавить
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+                <button
+                  onClick={() => fileInputRef.current?.click()}
+                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 transition-colors flex items-center"
+                >
+                  <Image size={14} className="mr-1" />
+                  Загрузить
                 </button>
               </div>
               {mediaInputError && (

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,22 @@
+import { supabase } from './supabase';
+
+const bucket = import.meta.env.VITE_SUPABASE_STORAGE_BUCKET || 'media';
+
+/**
+ * Upload a file to Supabase Storage and return the public URL.
+ */
+export const uploadFile = async (file: File): Promise<string> => {
+  const ext = file.name.split('.').pop() || 'bin';
+  const fileName = `${Date.now()}-${Math.random().toString(36).slice(2,8)}.${ext}`;
+
+  const { error } = await supabase.storage
+    .from(bucket)
+    .upload(fileName, file, { contentType: file.type });
+
+  if (error) {
+    throw error;
+  }
+
+  const { data } = supabase.storage.from(bucket).getPublicUrl(fileName);
+  return data.publicUrl;
+};


### PR DESCRIPTION
## Summary
- add helper to upload files to Supabase Storage
- validate media and compress before upload in `PostEditor`
- extend editor UI with file upload control
- document new `VITE_SUPABASE_STORAGE_BUCKET` env variable
- install `browser-image-compression`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417dcacf0c832eb5bec33a75292ffb