### PR TITLE
Implement role-based access

### DIFF
--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -14,7 +14,7 @@ interface CalendarDayProps {
 }
 
 const CalendarDay: React.FC<CalendarDayProps> = ({ date, posts, clients, onAddPost, className }) => {
-  const { setSelectedPost, setCurrentView } = useAppContext();
+  const { setSelectedPost, setCurrentView, role } = useAppContext();
   
   const day = format(date, 'd', { locale: ru });
   const isToday = new Date().toDateString() === date.toDateString();
@@ -43,13 +43,15 @@ const CalendarDay: React.FC<CalendarDayProps> = ({ date, posts, clients, onAddPo
                 {posts.length}
               </span>
             )}
-            <button 
-              onClick={onAddPost}
-              className="p-1.5 rounded-full bg-slate-600 hover:bg-slate-500 transition-colors"
-              aria-label="Add post"
-            >
-              <Plus size={18} />
-            </button>
+            {role !== 'viewer' && (
+              <button
+                onClick={onAddPost}
+                className="p-1.5 rounded-full bg-slate-600 hover:bg-slate-500 transition-colors"
+                aria-label="Add post"
+              >
+                <Plus size={18} />
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/Clients/AddClientModal.tsx
+++ b/src/components/Clients/AddClientModal.tsx
@@ -7,7 +7,7 @@ interface AddClientModalProps {
 }
 
 const AddClientModal: React.FC<AddClientModalProps> = ({ onClose }) => {
-  const { addClient } = useAppContext();
+  const { addClient, role } = useAppContext();
   const [name, setName] = useState('');
   const [industry, setIndustry] = useState('');
   const [logo, setLogo] = useState('');
@@ -126,13 +126,15 @@ const AddClientModal: React.FC<AddClientModalProps> = ({ onClose }) => {
             >
               Отмена
             </button>
-            <button
-              type="submit"
-              disabled={!name || !industry || loading}
-              className="flex-1 px-4 py-2 bg-cyan-600 rounded-lg hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {loading ? 'Добавление...' : 'Добавить'}
-            </button>
+            {role !== 'viewer' && (
+              <button
+                type="submit"
+                disabled={!name || !industry || loading}
+                className="flex-1 px-4 py-2 bg-cyan-600 rounded-lg hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {loading ? 'Добавление...' : 'Добавить'}
+              </button>
+            )}
           </div>
         </form>
       </div>

--- a/src/components/Clients/ClientCard.tsx
+++ b/src/components/Clients/ClientCard.tsx
@@ -12,7 +12,8 @@ const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
     setSelectedClient,
     setCurrentView,
     updateClient,
-    deleteClient
+    deleteClient,
+    role
   } = useAppContext();
 
   const handleCreatePost = () => {
@@ -80,26 +81,28 @@ const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
           </div>
         </div>
         
-        <div className="flex space-x-2">
-          <button
-            onClick={handleCreatePost}
-            className="flex-1 py-2 rounded bg-cyan-600 hover:bg-cyan-500 text-sm font-medium transition-colors"
-          >
-            Создать публикацию
-          </button>
-          <button
-            onClick={handleEdit}
-            className="p-2 rounded bg-slate-700 hover:bg-slate-600 transition-colors"
-          >
-            <Edit size={16} />
-          </button>
-          <button
-            onClick={handleDelete}
-            className="p-2 rounded bg-slate-700 hover:bg-red-700 transition-colors"
-          >
-            <Trash size={16} />
-          </button>
-        </div>
+        {role !== 'viewer' && (
+          <div className="flex space-x-2">
+            <button
+              onClick={handleCreatePost}
+              className="flex-1 py-2 rounded bg-cyan-600 hover:bg-cyan-500 text-sm font-medium transition-colors"
+            >
+              Создать публикацию
+            </button>
+            <button
+              onClick={handleEdit}
+              className="p-2 rounded bg-slate-700 hover:bg-slate-600 transition-colors"
+            >
+              <Edit size={16} />
+            </button>
+            <button
+              onClick={handleDelete}
+              className="p-2 rounded bg-slate-700 hover:bg-red-700 transition-colors"
+            >
+              <Trash size={16} />
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Clients/ClientsView.tsx
+++ b/src/components/Clients/ClientsView.tsx
@@ -5,20 +5,22 @@ import ClientCard from './ClientCard';
 import AddClientModal from './AddClientModal';
 
 const ClientsView: React.FC = () => {
-  const { clients } = useAppContext();
+  const { clients, role } = useAppContext();
   const [showAddClientModal, setShowAddClientModal] = useState(false);
 
   return (
     <div className="h-full flex flex-col">
       <div className="p-6 border-b border-slate-700 flex justify-between items-center">
         <h2 className="text-2xl font-bold">Клиенты</h2>
-        <button
-          onClick={() => setShowAddClientModal(true)}
-          className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 transition-colors flex items-center"
-        >
-          <Plus size={16} className="mr-2" />
-          Добавить клиента
-        </button>
+        {role !== 'viewer' && (
+          <button
+            onClick={() => setShowAddClientModal(true)}
+            className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 transition-colors flex items-center"
+          >
+            <Plus size={16} className="mr-2" />
+            Добавить клиента
+          </button>
+        )}
       </div>
 
       <div className="flex-1 p-6 overflow-y-auto">
@@ -31,13 +33,15 @@ const ClientsView: React.FC = () => {
             <p className="text-slate-400 mb-6 text-center max-w-md">
               Добавьте своего первого клиента, чтобы начать создавать и планировать контент.
             </p>
-            <button
-              onClick={() => setShowAddClientModal(true)}
-              className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 transition-colors flex items-center"
-            >
-              <Plus size={16} className="mr-2" />
-              Добавить клиента
-            </button>
+            {role !== 'viewer' && (
+              <button
+                onClick={() => setShowAddClientModal(true)}
+                className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 transition-colors flex items-center"
+              >
+                <Plus size={16} className="mr-2" />
+                Добавить клиента
+              </button>
+            )}
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -4,15 +4,16 @@ import { useAppContext } from '../../context/AppContext';
 import { formatLocalISO } from '../../utils/time';
 
 const PostEditor: React.FC = () => {
-  const { 
-    clients, 
-    posts, 
-    selectedPost, 
-    selectedClient, 
-    selectedDate, 
+  const {
+    clients,
+    posts,
+    selectedPost,
+    selectedClient,
+    selectedDate,
     setCurrentView,
     addPost,
-    updatePost
+    updatePost,
+    role
   } = useAppContext();
   
   const [content, setContent] = useState('');
@@ -140,14 +141,16 @@ const PostEditor: React.FC = () => {
           >
             Отмена
           </button>
-          <button
-            onClick={handleSavePost}
-            disabled={!content || !clientId || platforms.length === 0 || loading}
-            className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center"
-          >
-            <Send size={16} className="mr-2" />
-            {loading ? 'Сохранение...' : 'Запланировать'}
-          </button>
+          {role !== 'viewer' && (
+            <button
+              onClick={handleSavePost}
+              disabled={!content || !clientId || platforms.length === 0 || loading}
+              className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center"
+            >
+              <Send size={16} className="mr-2" />
+              {loading ? 'Сохранение...' : 'Запланировать'}
+            </button>
+          )}
         </div>
       </div>
       

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,3 +39,5 @@ export interface PostTemplate {
   content: string;
   industry?: string;
 }
+
+export type UserRole = 'viewer' | 'editor' | 'admin';

--- a/supabase/migrations/20250605113000_roles.sql
+++ b/supabase/migrations/20250605113000_roles.sql
@@ -1,0 +1,99 @@
+-- Add roles table
+CREATE TABLE public.roles (
+  user_id uuid PRIMARY KEY REFERENCES auth.users ON DELETE CASCADE,
+  role text NOT NULL DEFAULT 'editor' CHECK (role IN ('viewer','editor','admin'))
+);
+
+ALTER TABLE public.roles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their role" ON public.roles
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- Trigger to create default role entry on new user
+CREATE FUNCTION public.handle_new_user_role()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.roles (user_id) VALUES (NEW.id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER create_role_after_signup
+AFTER INSERT ON auth.users
+FOR EACH ROW EXECUTE FUNCTION public.handle_new_user_role();
+
+-- Update policies for clients
+DROP POLICY IF EXISTS "Users can manage their own clients" ON public.clients;
+
+CREATE POLICY "Select own clients or admin" ON public.clients
+  FOR SELECT USING (
+    auth.uid() = user_id OR EXISTS (
+      SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Modify own clients" ON public.clients
+  FOR INSERT, UPDATE, DELETE USING (
+    (auth.uid() = user_id AND EXISTS (
+      SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role IN ('editor','admin')
+    )) OR EXISTS (
+      SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+    )
+  ) WITH CHECK (
+    (auth.uid() = user_id AND EXISTS (
+      SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role IN ('editor','admin')
+    )) OR EXISTS (
+      SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+    )
+  );
+
+-- Update policies for posts
+DROP POLICY IF EXISTS "Users can manage posts through clients" ON public.posts;
+
+CREATE POLICY "Select own posts or admin" ON public.posts
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.clients c
+      WHERE c.id = posts.client_id AND (c.user_id = auth.uid() OR EXISTS (
+        SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+      ))
+    )
+  );
+
+CREATE POLICY "Modify own posts" ON public.posts
+  FOR INSERT, UPDATE, DELETE USING (
+    EXISTS (
+      SELECT 1 FROM public.clients c
+      WHERE c.id = posts.client_id AND ((c.user_id = auth.uid() AND EXISTS (
+        SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role IN ('editor','admin')
+      )) OR EXISTS (
+        SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+      ))
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.clients c
+      WHERE c.id = posts.client_id AND ((c.user_id = auth.uid() AND EXISTS (
+        SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role IN ('editor','admin')
+      )) OR EXISTS (
+        SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+      ))
+    )
+  );
+
+-- Update policies for templates
+DROP POLICY IF EXISTS "Authenticated users can read templates" ON public.templates;
+
+CREATE POLICY "Read templates" ON public.templates
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY "Manage templates as admin" ON public.templates
+  FOR INSERT, UPDATE, DELETE USING (
+    EXISTS (
+      SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.roles r WHERE r.user_id = auth.uid() AND r.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- add `roles` table migration with admin/editor/viewer roles
- extend AppContext to expose user role
- restrict client and post actions in the UI for viewers
- update RLS policies for clients, posts and templates

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417dea582c832eaab8a857a52784e1