### PR TITLE
Add OAuth login buttons

### DIFF
--- a/src/components/Auth/AuthLayout.tsx
+++ b/src/components/Auth/AuthLayout.tsx
@@ -2,12 +2,26 @@ import React, { useState } from 'react';
 import { useAppContext } from '../../context/AppContext';
 
 const AuthLayout: React.FC = () => {
-  const { signIn, signUp } = useAppContext();
+  const { signIn, signUp, signInWithOAuth } = useAppContext();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [isRegister, setIsRegister] = useState(false);
+
+  const handleOAuth = async (
+    provider: 'telegram' | 'vk' | 'google'
+  ) => {
+    setError('');
+    setLoading(true);
+    try {
+      await signInWithOAuth(provider);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred';
+      setError(message);
+      setLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -93,8 +107,35 @@ const AuthLayout: React.FC = () => {
               ) : (
                 isRegister ? 'Зарегистрироваться' : 'Войти'
               )}
-          </button>
-        </div>
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            <button
+              type="button"
+              onClick={() => handleOAuth('google')}
+              disabled={loading}
+              className="w-full flex justify-center py-2 px-4 rounded-md bg-slate-600 hover:bg-slate-500 text-white text-sm"
+            >
+              Войти через Google
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOAuth('telegram')}
+              disabled={loading}
+              className="w-full flex justify-center py-2 px-4 rounded-md bg-slate-600 hover:bg-slate-500 text-white text-sm"
+            >
+              Войти через Telegram
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOAuth('vk')}
+              disabled={loading}
+              className="w-full flex justify-center py-2 px-4 rounded-md bg-slate-600 hover:bg-slate-500 text-white text-sm"
+            >
+              Войти через VK
+            </button>
+          </div>
         <div className="text-center">
           {isRegister ? (
             <p className="text-sm text-slate-400">

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -4,6 +4,7 @@ import { supabase, handleSupabaseError } from '../lib/supabase';
 import { formatLocalISO } from '../utils/time';
 import sanitizeHtml from 'sanitize-html';
 import { User } from '@supabase/supabase-js';
+import type { Provider } from '@supabase/auth-js';
 
 interface AppContextType {
   clients: Client[];
@@ -28,6 +29,7 @@ interface AppContextType {
   deletePost: (postId: string) => Promise<void>;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string) => Promise<void>;
+  signInWithOAuth: (provider: 'telegram' | 'vk' | 'google') => Promise<void>;
   signOut: () => Promise<void>;
   clearError: () => void;
 }
@@ -263,6 +265,22 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     }
   };
 
+  const signInWithOAuth = async (
+    provider: 'telegram' | 'vk' | 'google'
+  ) => {
+    try {
+      setError(null);
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: provider as unknown as Provider,
+      });
+      if (error) throw error;
+    } catch (err) {
+      const errorMessage = handleSupabaseError(err);
+      setError(errorMessage);
+      throw new Error(errorMessage);
+    }
+  };
+
   const signOut = async () => {
     try {
       setError(null);
@@ -302,6 +320,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         deletePost,
         signIn,
         signUp,
+        signInWithOAuth,
         signOut,
         clearError,
       }}


### PR DESCRIPTION
## Summary
- add `signInWithOAuth` logic to AppContext for Telegram, VK and Google
- expose OAuth method to AuthLayout and provide provider buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417dce5d64832e869c0db2384292fa