### PR TITLE
Add inactivity logout and global sign-out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_INACTIVITY_TIMEOUT_MINUTES=30

--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@
 
 - `VITE_SUPABASE_URL` — адрес проекта Supabase
 - `VITE_SUPABASE_ANON_KEY` — публичный ключ (Anon Key)
+- `VITE_INACTIVITY_TIMEOUT_MINUTES` — время бездействия в минутах до автоматического выхода
 
 ## Пример `.env.example`
 
 ```bash
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_INACTIVITY_TIMEOUT_MINUTES=30
 ```
 
 ## Database setup

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,8 +3,9 @@ import { Calendar, Users, FileText, Lightbulb, LogOut, Loader } from 'lucide-rea
 import { useAppContext } from '../../context/AppContext';
 
 const Sidebar: React.FC = () => {
-  const { currentView, setCurrentView, signOut, error, clearError } = useAppContext();
+  const { currentView, setCurrentView, signOut, signOutAll, error, clearError } = useAppContext();
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [isSigningOutAll, setIsSigningOutAll] = useState(false);
 
   const handleSignOut = async () => {
     setIsSigningOut(true);
@@ -15,6 +16,18 @@ const Sidebar: React.FC = () => {
       // error is handled in context
     } finally {
       setIsSigningOut(false);
+    }
+  };
+
+  const handleSignOutAll = async () => {
+    setIsSigningOutAll(true);
+    clearError();
+    try {
+      await signOutAll();
+    } catch {
+      // error is handled in context
+    } finally {
+      setIsSigningOutAll(false);
     }
   };
 
@@ -85,6 +98,18 @@ const Sidebar: React.FC = () => {
             <LogOut size={20} className="mr-3" />
           )}
           Выйти
+        </button>
+        <button
+          onClick={handleSignOutAll}
+          disabled={isSigningOutAll}
+          className="w-full flex items-center rounded-lg px-4 py-3 mt-2 text-sm font-medium text-slate-300 hover:bg-slate-700/50 hover:text-white transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isSigningOutAll ? (
+            <Loader size={20} className="mr-3 animate-spin" />
+          ) : (
+            <LogOut size={20} className="mr-3" />
+          )}
+          Выйти везде
         </button>
         {error && (
           <div className="mt-4 px-4 py-2 bg-red-500/10 border border-red-500 text-red-400 rounded">


### PR DESCRIPTION
## Summary
- auto sign-out on inactivity in `AppContext`
- allow global sign-out from all devices
- expose configurable inactivity timeout in `.env`
- document timeout variable in `README`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68417dcccddc832ea97fc6cc5999af40