### PR TITLE
Add light/dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,14 @@ import { AppProvider } from './context/AppContext';
 import AppLayout from './components/Layout/AppLayout';
 import AuthLayout from './components/Auth/AuthLayout';
 import { useAppContext } from './context/AppContext';
+import ThemeToggle from './components/ThemeToggle';
 
 const AppContent = () => {
   const { user, loading } = useAppContext();
 
   if (loading) {
     return (
-      <div className="h-screen flex items-center justify-center bg-red-900">
+      <div className="h-screen flex items-center justify-center bg-background">
         <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-cyan-500"></div>
       </div>
     );
@@ -21,6 +22,7 @@ function App() {
   return (
     <AppProvider>
       <AppContent />
+      <ThemeToggle />
     </AppProvider>
   );
 }

--- a/src/components/Auth/AuthLayout.tsx
+++ b/src/components/Auth/AuthLayout.tsx
@@ -43,7 +43,7 @@ const AuthLayout: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-red-900 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <div className="max-w-md w-full space-y-8 bg-slate-800 p-8 rounded-lg">
         <div>
           <h2 className="text-center text-3xl font-bold text-white">

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -26,7 +26,7 @@ const AppLayout: React.FC = () => {
   };
 
   return (
-    <div className="flex h-screen bg-red-900 text-white">
+    <div className="flex h-screen bg-background text-text">
       <Sidebar />
       <main className="flex-1 flex flex-col overflow-y-auto">
         <div className="p-4">

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+const getInitialTheme = (): 'light' | 'dark' => {
+  if (typeof window === 'undefined') return 'light';
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light' || stored === 'dark') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState<'light' | 'dark'>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="fixed bottom-4 right-4 p-2 rounded-full bg-slate-600 text-white hover:bg-slate-500"
+    >
+      {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/index.css
+++ b/src/index.css
@@ -3,11 +3,19 @@
 @tailwind utilities;
 
 :root {
+  color-scheme: light;
+  --color-bg: #f8fafc;
+  --color-text: #0f172a;
+}
+
+.dark {
   color-scheme: dark;
+  --color-bg: #1e293b;
+  --color-text: #f8fafc;
 }
 
 body {
-  @apply bg-red-900 text-white;
+  @apply bg-background text-text;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,14 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: 'var(--color-bg)',
+        text: 'var(--color-text)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- implement theme variables and body styles
- enable `darkMode` and custom colors in Tailwind
- add ThemeToggle component
- use theme background in layouts

## Testing
- `npm test` *(fails: Jest cannot parse ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_684193d0ae98832eb3042c1ddda392ff