### PR TITLE
Improve component responsiveness

### DIFF
--- a/src/components/Auth/AuthLayout.tsx
+++ b/src/components/Auth/AuthLayout.tsx
@@ -44,7 +44,7 @@ const AuthLayout: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-red-900 flex items-center justify-center p-4">
-      <div className="max-w-md w-full space-y-8 bg-slate-800 p-8 rounded-lg">
+      <div className="max-w-md w-full space-y-8 bg-slate-800 p-4 md:p-8 rounded-lg">
         <div>
           <h2 className="text-center text-3xl font-bold text-white">
             {isRegister ? 'Регистрация в Chrono' : 'Войти в Chrono'}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -64,7 +64,7 @@ const Calendar: React.FC = () => {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="p-6 border-b border-slate-700">
+      <div className="p-4 md:p-6 border-b border-slate-700">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-bold">Календарь контента</h2>
           <div className="flex items-center space-x-4">
@@ -103,7 +103,7 @@ const Calendar: React.FC = () => {
             </div>
           </div>
         </div>
-        <div className="grid grid-cols-7 gap-4">
+        <div className="grid grid-cols-4 md:grid-cols-7 gap-4">
           {weekDays.map((day) => (
             <div key={`header-${day}`} className="text-center">
               <p className="text-sm text-slate-400 capitalize">
@@ -114,7 +114,7 @@ const Calendar: React.FC = () => {
         </div>
       </div>
 
-      <div className="flex-1 p-6 grid grid-cols-7 gap-4 h-full overflow-y-auto">
+      <div className="flex-1 p-4 md:p-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4 h-full overflow-y-auto">
         {weekDays.map((day) => {
           const postsForDay = filteredPosts.filter(post => 
             isSameDay(new Date(post.scheduledFor), day)

--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -34,7 +34,7 @@ const CalendarDay: React.FC<CalendarDayProps> = ({ date, posts, clients, onAddPo
         isToday ? 'ring-2 ring-cyan-500/50' : ''
       }`}
     >
-      <div className={`p-4 ${isToday ? 'bg-cyan-900/50' : 'bg-slate-700'}`}>
+      <div className={`p-3 md:p-4 ${isToday ? 'bg-cyan-900/50' : 'bg-slate-700'}`}>
         <div className="flex justify-between items-center">
           <p className={className || 'text-2xl font-bold text-white'}>{day}</p>
           <div className="flex items-center space-x-2">
@@ -56,7 +56,7 @@ const CalendarDay: React.FC<CalendarDayProps> = ({ date, posts, clients, onAddPo
         </div>
       </div>
 
-      <div className="flex-1 p-3 space-y-2 overflow-y-auto max-h-[300px] scrollbar-thin">
+      <div className="flex-1 p-2 md:p-3 space-y-2 overflow-y-auto max-h-[300px] scrollbar-thin">
         {posts.length === 0 ? (
           <div className="flex items-center justify-center h-full">
             <p className="text-sm text-slate-500">Нет публикаций</p>
@@ -68,7 +68,7 @@ const CalendarDay: React.FC<CalendarDayProps> = ({ date, posts, clients, onAddPo
               <div
                 key={post.id}
                 onClick={() => handlePostClick(post.id)}
-                className="group relative p-3 rounded-lg bg-slate-700 hover:bg-slate-600 cursor-pointer transition-all"
+                className="group relative p-2 md:p-3 rounded-lg bg-slate-700 hover:bg-slate-600 cursor-pointer transition-all"
                 style={{ borderLeft: `4px solid ${client?.color || '#94a3b8'}` }}
               >
                 <div className="flex items-center justify-between mb-2">

--- a/src/components/Calendar/ClientFilter.tsx
+++ b/src/components/Calendar/ClientFilter.tsx
@@ -41,7 +41,7 @@ const ClientFilter: React.FC<ClientFilterProps> = ({ clients, selectedClients, o
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-64 bg-slate-800 rounded-lg shadow-lg z-10 p-2 border border-slate-700">
+        <div className="absolute right-0 mt-2 w-60 sm:w-64 bg-slate-800 rounded-lg shadow-lg z-10 p-2 border border-slate-700">
           <div className="flex justify-between text-xs text-slate-400 p-2 border-b border-slate-700">
             <button
               onClick={selectAll}

--- a/src/components/Clients/AddClientModal.tsx
+++ b/src/components/Clients/AddClientModal.tsx
@@ -39,7 +39,7 @@ const AddClientModal: React.FC<AddClientModalProps> = ({ onClose }) => {
   
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-slate-800 rounded-lg w-full max-w-md p-6 relative">
+      <div className="bg-slate-800 rounded-lg w-full max-w-md p-4 md:p-6 relative">
         <button
           onClick={onClose}
           className="absolute top-4 right-4 text-slate-400 hover:text-white"

--- a/src/components/Clients/ClientCard.tsx
+++ b/src/components/Clients/ClientCard.tsx
@@ -37,7 +37,7 @@ const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
   return (
     <div className="bg-slate-800 rounded-lg overflow-hidden border border-slate-700 hover:border-slate-600 transition-colors">
       <div 
-        className="h-24 bg-gradient-to-r p-4 flex items-end"
+        className="h-24 bg-gradient-to-r p-3 md:p-4 flex items-end"
         style={{ 
           backgroundImage: client.logo 
             ? `linear-gradient(to right, ${client.color}80, ${client.color}), url(${client.logo})` 
@@ -49,7 +49,7 @@ const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
         <h3 className="text-xl font-bold text-white">{client.name}</h3>
       </div>
       
-      <div className="p-4">
+      <div className="p-3 md:p-4">
         <div className="flex items-center text-sm text-slate-400 mb-3">
           <span>Ниша:</span>
           <span className="ml-2 px-2 py-0.5 rounded bg-slate-700 text-white">

--- a/src/components/Clients/ClientsView.tsx
+++ b/src/components/Clients/ClientsView.tsx
@@ -10,7 +10,7 @@ const ClientsView: React.FC = () => {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="p-6 border-b border-slate-700 flex justify-between items-center">
+      <div className="p-4 md:p-6 border-b border-slate-700 flex justify-between items-center">
         <h2 className="text-2xl font-bold">Клиенты</h2>
         {role !== 'viewer' && (
           <button
@@ -23,10 +23,10 @@ const ClientsView: React.FC = () => {
         )}
       </div>
 
-      <div className="flex-1 p-6 overflow-y-auto">
+      <div className="flex-1 p-4 md:p-6 overflow-y-auto">
         {clients.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full">
-            <div className="p-6 bg-slate-800 rounded-full mb-4">
+            <div className="p-4 md:p-6 bg-slate-800 rounded-full mb-4">
               <Users size={32} className="text-slate-400" />
             </div>
             <h3 className="text-xl font-medium mb-2">Нет клиентов</h3>

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -29,7 +29,7 @@ const AppLayout: React.FC = () => {
     <div className="flex h-screen bg-red-900 text-white">
       <Sidebar />
       <main className="flex-1 flex flex-col overflow-y-auto">
-        <div className="p-4">
+        <div className="p-2 md:p-4">
           <Alert />
         </div>
         <div className="flex-1 overflow-y-auto">

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -55,8 +55,8 @@ const Sidebar: React.FC = () => {
   ];
 
   return (
-    <aside className="w-64 bg-slate-800 border-r border-slate-700 flex flex-col">
-      <div className="p-6">
+    <aside className="w-56 md:w-64 bg-slate-800 border-r border-slate-700 flex flex-col">
+      <div className="p-4 md:p-6">
         <h1 className="text-2xl font-bold text-white flex items-center">
           <Calendar className="mr-2 text-cyan-400" />
           Chrono
@@ -66,7 +66,7 @@ const Sidebar: React.FC = () => {
         </p>
       </div>
 
-      <nav className="flex-1 p-4">
+      <nav className="flex-1 p-2 md:p-4">
         <ul className="space-y-2">
           {navItems.map((item) => (
             <li key={item.view}>
@@ -86,7 +86,7 @@ const Sidebar: React.FC = () => {
         </ul>
       </nav>
 
-      <div className="p-4 border-t border-slate-700">
+      <div className="p-2 md:p-4 border-t border-slate-700">
         <button
           onClick={handleSignOut}
           disabled={isSigningOut}

--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -167,7 +167,7 @@ const PostEditor: React.FC = () => {
   
   return (
     <div className="h-full flex flex-col">
-      <div className="p-6 border-b border-slate-700 flex justify-between items-center">
+      <div className="p-4 md:p-6 border-b border-slate-700 flex justify-between items-center">
         <h2 className="text-2xl font-bold">
           {selectedPost ? 'Редактировать публикацию' : 'Новая публикация'}
         </h2>
@@ -191,14 +191,14 @@ const PostEditor: React.FC = () => {
         </div>
       </div>
       
-      <div className="flex-1 p-6 overflow-y-auto">
+      <div className="flex-1 p-4 md:p-6 overflow-y-auto">
         {error && (
           <div className="mb-4 px-4 py-2 bg-red-500/10 border border-red-500 text-red-400 rounded">
             {error}
           </div>
         )}
-        <div className="grid grid-cols-3 gap-6">
-          <div className="col-span-2 space-y-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 space-y-6">
             <div className="space-y-2">
               <label className="block text-sm font-medium text-slate-300">Клиент</label>
               <select
@@ -279,7 +279,7 @@ const PostEditor: React.FC = () => {
                   ))}
                 </div>
               ) : (
-                <div className="p-6 border-2 border-dashed border-slate-700 rounded-lg flex items-center justify-center">
+                <div className="p-4 md:p-6 border-2 border-dashed border-slate-700 rounded-lg flex items-center justify-center">
                   <p className="text-slate-500 text-sm">Нет добавленных медиафайлов</p>
                 </div>
               )}

--- a/src/components/Templates/TemplatesView.tsx
+++ b/src/components/Templates/TemplatesView.tsx
@@ -13,14 +13,14 @@ const TemplatesView: React.FC = () => {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="p-6 border-b border-slate-700">
+      <div className="p-4 md:p-6 border-b border-slate-700">
         <h2 className="text-2xl font-bold">Идеи для контента</h2>
         <p className="text-slate-400 mt-1">
           Готовые шаблоны для различных типов публикаций
         </p>
       </div>
 
-      <div className="flex-1 p-6 overflow-y-auto">
+      <div className="flex-1 p-4 md:p-6 overflow-y-auto">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {templates.map((template) => (
             <div 


### PR DESCRIPTION
## Summary
- tweak sidebar width and padding so it's responsive
- use responsive spacing in main layout and calendar views
- adjust clients and posts interfaces for mobile
- add responsive rules to authentication and template pages

## Testing
- `npm run dev` *(fails: http warning; dev server started)*
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684193d11d18832ea51fbf2de1da72ab