### PR TITLE
Fix logout section wrapper

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -87,6 +87,8 @@ const Sidebar: React.FC = () => {
         </ul>
       </nav>
 
+      <div className="p-2 md:p-4 border-t border-slate-700">
+        <Button
           onClick={handleSignOut}
           disabled={isSigningOut}
           className="w-full flex items-center rounded-lg px-4 py-3 text-sm text-slate-300 hover:bg-slate-700/50 hover:text-white"


### PR DESCRIPTION
## Summary
- restore missing container around sign out buttons

## Testing
- `npm test --silent` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841bfe5b9d8832eaf966caf273889e1