### PR TITLE
Add media url input state

### DIFF
--- a/src/components/Auth/AuthLayout.tsx
+++ b/src/components/Auth/AuthLayout.tsx
@@ -45,6 +45,8 @@ const AuthLayout: React.FC = () => {
   };
 
   return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="w-full max-w-md space-y-8 p-4">
         <div>
           <h2 className="text-center text-3xl font-bold text-white">
             {isRegister ? 'Регистрация в Chrono' : 'Войти в Chrono'}
@@ -54,7 +56,7 @@ const AuthLayout: React.FC = () => {
           </p>
         </div>
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+        <form className="space-y-6" onSubmit={handleSubmit}>
           {error && (
             <div className="bg-red-500/10 border border-red-500 text-red-400 px-4 py-3 rounded">
               {error}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -87,6 +87,8 @@ const Sidebar: React.FC = () => {
         </ul>
       </nav>
 
+      <div className="p-2 md:p-4 border-t border-slate-700">
+        <Button
           onClick={handleSignOut}
           disabled={isSigningOut}
           className="w-full flex items-center rounded-lg px-4 py-3 text-sm text-slate-300 hover:bg-slate-700/50 hover:text-white"

--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -4,6 +4,8 @@ import { useAppContext } from '../../context/AppContext';
 import { formatLocalISO } from '../../utils/time';
 import imageCompression from 'browser-image-compression';
 import { uploadFile } from '../../lib/storage';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
 
 const PostEditor: React.FC = () => {
   const {
@@ -227,35 +229,24 @@ const PostEditor: React.FC = () => {
             <div className="space-y-2">
               <label className="block text-sm font-medium text-slate-300">Медиа</label>
               <div className="flex space-x-2">
-                <input
+                <Input
                   type="url"
                   value={mediaUrlInput}
                   onChange={(e) => setMediaUrlInput(e.target.value)}
                   placeholder="https://example.com/image.jpg"
-                  className="flex-1 p-3 bg-slate-800 rounded-lg border border-slate-700 focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+                  className="flex-1"
                 />
-                <button
-                  onClick={handleAddMedia}
-                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 transition-colors flex items-center"
-                >
+                <Button type="button" onClick={handleAddMedia} className="flex items-center px-3 py-2 bg-slate-700 hover:bg-slate-600">
                   <Image size={14} className="mr-1" />
                   Добавить
-                </button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={handleFileChange}
-                  className="hidden"
-                />
-                <button
-                  onClick={() => fileInputRef.current?.click()}
-                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 transition-colors flex items-center"
-                >
-                  <Image size={14} className="mr-1" />
-                  Загрузить
-                </button>
+                </Button>
               </div>
+              <Input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+              />
               {mediaInputError && (
                 <p className="text-sm text-red-500">{mediaInputError}</p>
               )}


### PR DESCRIPTION
## Summary
- enhance PostEditor with dedicated media inputs
- fix missing markup around auth layout
- repair Sidebar sign out buttons

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841bfe850b0832ebd4169f967e57a67