### PR TITLE
Use getSupabase helper

### DIFF
--- a/src/context/__tests__/AppContext.test.tsx
+++ b/src/context/__tests__/AppContext.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { AppProvider, useAppContext } from '../AppContext';
-import { supabase } from '../../lib/supabase';
+import { getSupabase } from '../../lib/supabase';
 
 jest.mock('../../lib/supabase', () => {
   const signInWithPassword = jest.fn();
@@ -9,14 +9,17 @@ jest.mock('../../lib/supabase', () => {
   const signUp = jest.fn();
   const onAuthStateChange = jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } }));
   const getSession = jest.fn().mockResolvedValue({ data: { session: null } });
+  const supabase = {
+    auth: { signInWithPassword, signOut, signUp, onAuthStateChange, getSession },
+    from: jest.fn(() => ({ select: jest.fn().mockReturnThis(), order: jest.fn().mockReturnThis() }))
+  };
   return {
-    supabase: {
-      auth: { signInWithPassword, signOut, signUp, onAuthStateChange, getSession },
-      from: jest.fn(() => ({ select: jest.fn().mockReturnThis(), order: jest.fn().mockReturnThis() }))
-    },
+    getSupabase: jest.fn(() => supabase),
     handleSupabaseError: jest.fn().mockImplementation((e: unknown) => e instanceof Error ? e.message : 'unknown')
   };
 });
+
+const supabase = getSupabase();
 
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <AppProvider>{children}</AppProvider>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -5,19 +5,29 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 let supabase: SupabaseClient | null = null;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.error('Missing Supabase environment variables');
-} else {
-  supabase = createClient(supabaseUrl, supabaseAnonKey, {
+const createSupabase = () =>
+  createClient(supabaseUrl!, supabaseAnonKey!, {
     auth: {
       persistSession: true,
       autoRefreshToken: true,
-      detectSessionInUrl: true
-    }
+      detectSessionInUrl: true,
+    },
   });
+
+if (supabaseUrl && supabaseAnonKey) {
+  supabase = createSupabase();
+} else {
+  console.error('Missing Supabase environment variables');
 }
 
-export { supabase };
+export const getSupabase = (): SupabaseClient => {
+  if (supabase) return supabase;
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Supabase credentials not configured');
+  }
+  supabase = createSupabase();
+  return supabase;
+};
 
 // Helper to handle Supabase errors
 export const handleSupabaseError = (error: unknown) => {


### PR DESCRIPTION
## Summary
- create a `getSupabase` helper that throws on missing credentials
- use `getSupabase` inside `AppContext`
- update tests to mock the new helper

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841d3945014832e8eda1e1a4dece318