### PR TITLE
Switch to DOMPurify for HTML sanitization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "browser-image-compression": "^2.0.1",
         "date-fns": "^3.3.1",
         "date-fns-tz": "^3.2.0",
+        "dompurify": "^3.2.6",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "sanitize-html": "^2.11.0"
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -27,7 +27,6 @@
         "@types/jest": "^29.5.14",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
-        "@types/sanitize-html": "^2.11.0",
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.18",
         "cypress": "^13.7.3",
@@ -2200,14 +2199,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/sanitize-html": {
-      "version": "2.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "htmlparser2": "^8.0.0"
-      }
-    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
       "dev": true,
@@ -2227,6 +2218,13 @@
       "version": "4.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3805,6 +3803,7 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3912,28 +3911,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "dev": true,
@@ -3945,29 +3922,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -4070,16 +4031,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -4202,6 +4153,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5142,23 +5094,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "license": "MIT",
@@ -5552,13 +5487,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -7289,6 +7217,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7561,10 +7490,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-srcset": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "dev": true,
@@ -7659,6 +7584,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -7757,6 +7683,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.4",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8361,18 +8288,6 @@
       "version": "2.1.2",
       "license": "MIT"
     },
-    "node_modules/sanitize-html": {
-      "version": "2.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      }
-    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "dev": true,
@@ -8610,6 +8525,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sanitize-html": "^2.11.0"
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -32,7 +32,6 @@
     "@types/jest": "^29.5.14",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
-    "@types/sanitize-html": "^2.11.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.18",
     "cypress": "^13.7.3",

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -3,7 +3,7 @@ import { Client, Post, PostTemplate, UserRole } from '../types';
 import { supabase, handleSupabaseError } from '../lib/supabase';
 import { apiRequest } from '../lib/api';
 import { formatLocalISO } from '../utils/time';
-import sanitizeHtml from 'sanitize-html';
+import DOMPurify from 'dompurify';
 import { User } from '@supabase/supabase-js';
 import type { Provider } from '@supabase/auth-js';
 
@@ -174,7 +174,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const addPost = async (post: Omit<Post, 'id' | 'createdAt' | 'updatedAt'>) => {
     try {
       setError(null);
-      const sanitizedContent = sanitizeHtml(post.content);
+      const sanitizedContent = DOMPurify.sanitize(post.content);
       const now = formatLocalISO(new Date());
 
       const data = await apiRequest<Post>('/posts', {
@@ -199,7 +199,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       setError(null);
       if (updates.content) {
-        updates.content = sanitizeHtml(updates.content);
+        updates.content = DOMPurify.sanitize(updates.content);
       }
       updates.updatedAt = formatLocalISO(new Date());
 


### PR DESCRIPTION
## Summary
- swap `sanitize-html` for `dompurify`
- update `AppContext` to use DOMPurify

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841d3988ac8832e87ecd8d86ee23699