### PR TITLE
Add product editor view

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import Calendar from '../Calendar/Calendar';
 import ClientsView from '../Clients/ClientsView';
 import PostEditor from '../Posts/PostEditor';
 import TemplatesView from '../Templates/TemplatesView';
+import ProductEditor from '../Products/ProductEditor';
 import Alert from '../Alert';
 
 const AppLayout: React.FC = () => {
@@ -18,6 +19,8 @@ const AppLayout: React.FC = () => {
         return <ClientsView />;
       case 'post-editor':
         return <PostEditor />;
+      case 'product-editor':
+        return <ProductEditor />;
       case 'templates':
         return <TemplatesView />;
       default:

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Calendar, Users, FileText, Lightbulb, LogOut, Loader } from 'lucide-react';
+import { Calendar, Users, FileText, Lightbulb, Package, LogOut, Loader } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import Button from '../ui/Button';
 
@@ -47,6 +47,11 @@ const Sidebar: React.FC = () => {
       icon: <FileText size={20} />,
       label: 'Редактор',
       view: 'post-editor' as const,
+    },
+    {
+      icon: <Package size={20} />,
+      label: 'Продукты',
+      view: 'product-editor' as const,
     },
     {
       icon: <Lightbulb size={20} />,

--- a/src/components/Products/ProductEditor.tsx
+++ b/src/components/Products/ProductEditor.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useRef } from 'react';
+import { Package, Image as ImageIcon, Plus, X } from 'lucide-react';
+import Input from '../ui/Input';
+import Button from '../ui/Button';
+
+const ctaOptions = ['Buy Now', 'Learn More', 'Sign Up', 'Get Started'];
+
+const ProductEditor: React.FC = () => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState('');
+  const [promoEnabled, setPromoEnabled] = useState(false);
+  const [promoPrice, setPromoPrice] = useState('');
+  const [images, setImages] = useState<File[]>([]);
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
+  const [highlightInput, setHighlightInput] = useState('');
+  const [highlights, setHighlights] = useState<string[]>([]);
+  const [cta, setCta] = useState(ctaOptions[0]);
+  const [demoInput, setDemoInput] = useState('');
+  const [demoLinks, setDemoLinks] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [errors, setErrors] = useState<{[k:string]: string}>({});
+
+  const validate = () => {
+    const newErrors: {[k:string]: string} = {};
+    if (!name.trim()) newErrors.name = 'Name is required';
+    const p = parseFloat(price);
+    if (!price.trim() || isNaN(p) || p <= 0) newErrors.price = 'Enter valid price';
+    if (promoEnabled) {
+      const promo = parseFloat(promoPrice);
+      if (!promoPrice.trim() || isNaN(promo) || promo <= 0) {
+        newErrors.promoPrice = 'Enter valid promo price';
+      } else if (!isNaN(p) && promo >= p) {
+        newErrors.promoPrice = 'Promo price should be less than price';
+      }
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleFiles = (files: FileList) => {
+    const newFiles: File[] = [];
+    const newPreviews: string[] = [];
+    Array.from(files).forEach(f => {
+      newFiles.push(f);
+      newPreviews.push(URL.createObjectURL(f));
+    });
+    setImages(prev => [...prev, ...newFiles]);
+    setImagePreviews(prev => [...prev, ...newPreviews]);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (e.dataTransfer.files) handleFiles(e.dataTransfer.files);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) handleFiles(e.target.files);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const removeImage = (index: number) => {
+    setImages(imgs => imgs.filter((_, i) => i !== index));
+    setImagePreviews(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const addHighlight = () => {
+    if (!highlightInput.trim()) return;
+    setHighlights(prev => [...prev, highlightInput.trim()]);
+    setHighlightInput('');
+  };
+
+  const removeHighlight = (index: number) => {
+    setHighlights(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const addDemoLink = () => {
+    if (!demoInput.trim()) return;
+    try {
+      const url = new URL(demoInput.trim());
+      setDemoLinks(prev => [...prev, url.toString()]);
+      setDemoInput('');
+    } catch {
+      setErrors(err => ({ ...err, demoInput: 'Invalid URL' }));
+    }
+  };
+
+  const removeDemoLink = (index: number) => {
+    setDemoLinks(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = () => {
+    if (!validate()) return;
+    // For demo just log product info
+    const product = {
+      name,
+      description,
+      price: parseFloat(price),
+      promoPrice: promoEnabled ? parseFloat(promoPrice) : undefined,
+      highlights,
+      cta,
+      demoLinks,
+      imagesCount: images.length
+    };
+    console.log('Product saved', product);
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="p-4 md:p-6 border-b border-slate-700 flex items-center justify-between">
+        <h2 className="text-2xl font-bold flex items-center">
+          <Package className="mr-2" />Product Editor
+        </h2>
+        <Button onClick={handleSubmit} variant="primary">
+          Save
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Name</label>
+          <Input value={name} onChange={e => setName(e.target.value)} placeholder="Product name" />
+          {errors.name && <p className="text-sm text-red-500">{errors.name}</p>}
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Description</label>
+          <textarea
+            className="w-full p-3 rounded-lg bg-slate-800 border border-slate-700 focus:ring-2 focus:ring-cyan-500 focus:border-transparent resize-none"
+            rows={4}
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Describe your product"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Images</label>
+          <div
+            onDragOver={e => e.preventDefault()}
+            onDrop={handleDrop}
+            className="p-6 border-2 border-dashed border-slate-700 rounded-lg text-center cursor-pointer"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <p className="text-slate-400 flex items-center justify-center"><ImageIcon className="mr-2" size={18}/> Drop or click to upload</p>
+            <input ref={fileInputRef} type="file" multiple className="hidden" onChange={handleFileChange} />
+          </div>
+          {imagePreviews.length > 0 && (
+            <div className="grid grid-cols-3 gap-3 mt-3">
+              {imagePreviews.map((src, idx) => (
+                <div key={idx} className="relative group">
+                  <img src={src} className="w-full h-24 object-cover rounded" />
+                  <button
+                    type="button"
+                    onClick={() => removeImage(idx)}
+                    className="absolute top-1 right-1 p-1 bg-slate-800/80 rounded-full opacity-0 group-hover:opacity-100"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Price</label>
+          <Input type="number" value={price} onChange={e => setPrice(e.target.value)} />
+          {errors.price && <p className="text-sm text-red-500">{errors.price}</p>}
+          <div className="flex items-center space-x-2 mt-2">
+            <input type="checkbox" checked={promoEnabled} onChange={e => setPromoEnabled(e.target.checked)} />
+            <span className="text-sm">Promo price</span>
+          </div>
+          {promoEnabled && (
+            <div className="mt-2">
+              <Input type="number" value={promoPrice} onChange={e => setPromoPrice(e.target.value)} placeholder="Promo price" />
+              {errors.promoPrice && <p className="text-sm text-red-500">{errors.promoPrice}</p>}
+            </div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Highlights</label>
+          <div className="flex space-x-2">
+            <Input value={highlightInput} onChange={e => setHighlightInput(e.target.value)} placeholder="Add highlight" className="flex-1" />
+            <Button type="button" onClick={addHighlight} className="px-2"><Plus size={16}/></Button>
+          </div>
+          {highlights.length > 0 && (
+            <ul className="list-disc list-inside space-y-1 mt-2">
+              {highlights.map((h, idx) => (
+                <li key={idx} className="flex items-center">
+                  <span className="flex-1">{h}</span>
+                  <button type="button" onClick={() => removeHighlight(idx)} className="ml-2 text-slate-400 hover:text-white">
+                    <X size={14} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">CTA Button</label>
+          <select value={cta} onChange={e => setCta(e.target.value)} className="w-full p-3 bg-slate-800 rounded-lg border border-slate-700 focus:ring-2 focus:ring-cyan-500 focus:border-transparent">
+            {ctaOptions.map(option => (
+              <option key={option} value={option}>{option}</option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Demo links</label>
+          <div className="flex space-x-2">
+            <Input value={demoInput} onChange={e => setDemoInput(e.target.value)} placeholder="https://example.com" className="flex-1" />
+            <Button type="button" onClick={addDemoLink} className="px-2"><Plus size={16}/></Button>
+          </div>
+          {errors.demoInput && <p className="text-sm text-red-500">{errors.demoInput}</p>}
+          {demoLinks.length > 0 && (
+            <ul className="space-y-1 mt-2">
+              {demoLinks.map((link, idx) => (
+                <li key={idx} className="flex items-center text-cyan-400">
+                  <a href={link} target="_blank" rel="noopener noreferrer" className="underline flex-1 break-all">{link}</a>
+                  <button type="button" onClick={() => removeDemoLink(idx)} className="ml-2 text-slate-400 hover:text-white">
+                    <X size={14} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductEditor;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -11,7 +11,7 @@ interface AppContextType {
   clients: Client[];
   posts: Post[];
   templates: PostTemplate[];
-  currentView: 'calendar' | 'clients' | 'templates' | 'post-editor';
+  currentView: 'calendar' | 'clients' | 'templates' | 'post-editor' | 'product-editor';
   selectedClient: string | null;
   selectedDate: string | null;
   selectedPost: string | null;
@@ -19,7 +19,7 @@ interface AppContextType {
   role: UserRole | null;
   loading: boolean;
   error: string | null;
-  setCurrentView: (view: 'calendar' | 'clients' | 'templates' | 'post-editor') => void;
+  setCurrentView: (view: 'calendar' | 'clients' | 'templates' | 'post-editor' | 'product-editor') => void;
   setSelectedClient: (clientId: string | null) => void;
   setSelectedDate: (date: string | null) => void;
   setSelectedPost: (postId: string | null) => void;
@@ -44,7 +44,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const [clients, setClients] = useState<Client[]>([]);
   const [posts, setPosts] = useState<Post[]>([]);
   const [templates, setTemplates] = useState<PostTemplate[]>([]);
-  const [currentView, setCurrentView] = useState<'calendar' | 'clients' | 'templates' | 'post-editor'>('calendar');
+  const [currentView, setCurrentView] = useState<'calendar' | 'clients' | 'templates' | 'post-editor' | 'product-editor'>('calendar');
   const [selectedClient, setSelectedClient] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedPost, setSelectedPost] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- create `ProductEditor` with local state and validation
- add product editing view to the context and main layout
- extend sidebar navigation to reach the product editor

## Testing
- `npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841de684a80832e95bed94495601d2e