### PR TITLE
Update ClientFilter checkboxes

### DIFF
--- a/src/components/Calendar/ClientFilter.tsx
+++ b/src/components/Calendar/ClientFilter.tsx
@@ -58,11 +58,17 @@ const ClientFilter: React.FC<ClientFilterProps> = ({ clients, selectedClients, o
           </div>
           <div className="mt-2 max-h-60 overflow-y-auto">
             {clients.map(client => (
-              <div
+              <label
                 key={client.id}
                 className="flex items-center px-3 py-2 hover:bg-slate-700 rounded cursor-pointer"
-                onClick={() => toggleClient(client.id)}
               >
+                <input
+                  type="checkbox"
+                  value={client.id}
+                  checked={selectedClients.includes(client.id)}
+                  onChange={() => toggleClient(client.id)}
+                  className="sr-only"
+                />
                 <div className="flex-shrink-0 w-6 h-6 rounded-full overflow-hidden mr-3" style={{ backgroundColor: client.color }}>
                   {client.logo && <img src={client.logo} alt={client.name} className="w-full h-full object-cover" />}
                 </div>
@@ -72,7 +78,7 @@ const ClientFilter: React.FC<ClientFilterProps> = ({ clients, selectedClients, o
                     <Check size={14} className="text-cyan-400" />
                   )}
                 </div>
-              </div>
+              </label>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace clickable divs with checkbox labels in ClientFilter
- maintain selected state via selectedClients array

## Testing
- `npm run lint`
- `npm run test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841e1561d14832eb4b2a63d51823ca7