### PR TITLE
Update platform selectors to checkboxes

### DIFF
--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -150,12 +150,16 @@ const PostEditor: React.FC = () => {
     setMediaUrls(mediaUrls.filter((_, i) => i !== index));
   };
   
-  const togglePlatform = (platform: 'telegram' | 'vk' | 'instagram') => {
-    if (platforms.includes(platform)) {
-      setPlatforms(platforms.filter(p => p !== platform));
-    } else {
-      setPlatforms([...platforms, platform]);
-    }
+  const togglePlatform = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const platform = e.target.value as 'telegram' | 'vk' | 'instagram';
+    const { checked } = e.target;
+
+    setPlatforms(current => {
+      if (checked) {
+        return current.includes(platform) ? current : [...current, platform];
+      }
+      return current.filter(p => p !== platform);
+    });
   };
   
   const isPlatformAvailable = (platform: 'telegram' | 'vk' | 'instagram') => {
@@ -312,11 +316,10 @@ const PostEditor: React.FC = () => {
                 ].map(platform => {
                   const isAvailable = isPlatformAvailable(platform.id as 'telegram' | 'vk' | 'instagram');
                   const isSelected = platforms.includes(platform.id as 'telegram' | 'vk' | 'instagram');
-                  
+
                   return (
-                    <div
+                    <label
                       key={platform.id}
-                      onClick={() => isAvailable && togglePlatform(platform.id as 'telegram' | 'vk' | 'instagram')}
                       className={`flex items-center p-3 rounded-lg border ${
                         isAvailable
                           ? isSelected
@@ -325,16 +328,28 @@ const PostEditor: React.FC = () => {
                           : 'border-slate-700 bg-slate-800/50 opacity-50 cursor-not-allowed'
                       } ${isAvailable ? 'cursor-pointer hover:bg-slate-700' : ''} transition-colors`}
                     >
-                      <div className={`w-5 h-5 rounded mr-3 flex items-center justify-center ${
-                        isSelected ? 'bg-cyan-500' : 'bg-slate-700'
-                      }`}>
+                      <input
+                        type="checkbox"
+                        value={platform.id}
+                        checked={isSelected}
+                        disabled={!isAvailable}
+                        onChange={togglePlatform}
+                        aria-label={`Выбрать ${platform.name}`}
+                        className="sr-only"
+                      />
+                      <div
+                        className={`w-5 h-5 rounded mr-3 flex items-center justify-center ${
+                          isSelected ? 'bg-cyan-500' : 'bg-slate-700'
+                        }`}
+                        aria-hidden="true"
+                      >
                         {isSelected && <Check size={14} />}
                       </div>
                       <span>{platform.name}</span>
                       {!isAvailable && (
                         <span className="ml-auto text-xs text-slate-500">Не подключено</span>
                       )}
-                    </div>
+                    </label>
                   );
                 })}
               </div>


### PR DESCRIPTION
## Summary
- use checkbox inputs for choosing platforms in PostEditor
- keep styling with Tailwind classes
- adapt togglePlatform to read checkbox change events
- add aria labels for clarity

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841e157669c832ea9b459f6cb01243b