### PR TITLE
Add toast notification after saving posts

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -7,6 +7,7 @@ import PostEditor from '../Posts/PostEditor';
 import TemplatesView from '../Templates/TemplatesView';
 import ProductEditor from '../Products/ProductEditor';
 import Alert from '../Alert';
+import Toast from '../ui/Toast';
 
 const AppLayout: React.FC = () => {
   const { currentView } = useAppContext();
@@ -34,6 +35,7 @@ const AppLayout: React.FC = () => {
       <main className="flex-1 flex flex-col overflow-y-auto">
         <div className="p-2 md:p-4">
           <Alert />
+          <Toast />
         </div>
         <div className="flex-1 overflow-y-auto">
           {renderCurrentView()}

--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -17,6 +17,7 @@ const PostEditor: React.FC = () => {
     setCurrentView,
     addPost,
     updatePost,
+    showNotification,
     role
   } = useAppContext();
   
@@ -92,6 +93,7 @@ const PostEditor: React.FC = () => {
         });
       }
 
+      showNotification('Публикация сохранена');
       setCurrentView('calendar');
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An error occurred';

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { useAppContext } from '../../context/AppContext';
+
+interface ToastProps {
+  duration?: number;
+}
+
+const Toast: React.FC<ToastProps> = ({ duration = 3000 }) => {
+  const { notification, clearNotification } = useAppContext();
+
+  useEffect(() => {
+    if (!notification) return;
+    const timer = setTimeout(() => {
+      clearNotification();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [notification, duration, clearNotification]);
+
+  if (!notification) return null;
+
+  return (
+    <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow flex items-start">
+      <span className="pr-2">{notification}</span>
+      <button onClick={clearNotification} className="ml-2 text-white/70 hover:text-white">
+        <X size={16} />
+      </button>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -36,6 +36,9 @@ interface AppContextType {
   signOutAll: () => Promise<void>;
   lastActivity: number;
   clearError: () => void;
+  notification: string | null;
+  showNotification: (message: string) => void;
+  clearNotification: () => void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -52,6 +55,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const [role, setRole] = useState<UserRole | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [notification, setNotification] = useState<string | null>(null);
   const [lastActivity, setLastActivity] = useState<number>(Date.now());
 
   const inactivityMinutes = Number(import.meta.env.VITE_INACTIVITY_TIMEOUT_MINUTES || 0);
@@ -328,6 +332,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   }, [lastActivity, inactivityMs]);
 
   const clearError = () => setError(null);
+  const showNotification = (message: string) => setNotification(message);
+  const clearNotification = () => setNotification(null);
 
   return (
     <AppContext.Provider
@@ -360,6 +366,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         signOutAll,
         lastActivity,
         clearError,
+        notification,
+        showNotification,
+        clearNotification,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- create a simple `Toast` UI component
- expose notification helpers in `AppContext`
- render toast in `AppLayout`
- show toast after a post is saved

## Testing
- `npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841e159ceb4832e94800b7acab251c2