### PR TITLE
Fix platform selector accessibility

### DIFF
--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -318,6 +318,7 @@ const PostEditor: React.FC = () => {
                   return (
                     <label
                       key={platform.id}
+                      aria-label={`Выбрать ${platform.name}`}
                       className={`flex items-center p-3 rounded-lg border ${
                         isAvailable
                           ? isSelected
@@ -332,7 +333,6 @@ const PostEditor: React.FC = () => {
                         checked={isSelected}
                         disabled={!isAvailable}
                         onChange={togglePlatform}
-                        aria-label={`Выбрать ${platform.name}`}
                         className="sr-only"
                       />
                       <div


### PR DESCRIPTION
## Summary
- add `aria-label` to the platform checkbox label

## Testing
- `npm test` *(fails: ReferenceError: toastMessage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841e3d08a5c832e9a43562e147c413b