### PR TITLE
Fix JSX closing tag in ClientFilter

### DIFF
--- a/src/components/Calendar/ClientFilter.tsx
+++ b/src/components/Calendar/ClientFilter.tsx
@@ -67,7 +67,7 @@ const ClientFilter: React.FC<ClientFilterProps> = ({ clients, selectedClients, o
                   value={client.id}
                   checked={selectedClients.includes(client.id)}
                   onChange={() => toggleClient(client.id)}
-                </div>
+                />
                 <span className="flex-1 text-sm">{client.name}</span>
                 <div className="w-5 h-5 rounded border border-slate-600 flex items-center justify-center">
                   {selectedClients.includes(client.id) && (


### PR DESCRIPTION
## Summary
- fix closing tag for ClientFilter checkbox

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: toastMessage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841e794ee4c832eb48bdb2e650ed8c2