### PR TITLE
Add meta description to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Веб-приложение для планирования публикаций в соцсетях">
     <title>Chrono | Контент по расписанию</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add meta description tag to the document head

## Testing
- `npm run lint` *(fails: Parsing error and unused vars in unrelated files)*
- `npm run test` *(fails: toastMessage is not defined in AppContext tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841e794fc0c832eaa009d7d71c97a2b