### PR TITLE
Fix duplicate ProductEditor import

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -4,7 +4,6 @@ import Sidebar from './Sidebar';
 import Calendar from '../Calendar/Calendar';
 import ClientsView from '../Clients/ClientsView';
 import PostEditor from '../Posts/PostEditor';
-import ProductEditor from '../Posts/ProductEditor';
 import TemplatesView from '../Templates/TemplatesView';
 import ProductEditor from '../Products/ProductEditor';
 import Alert from '../Alert';


### PR DESCRIPTION
## Summary
- remove unused ProductEditor import from Posts folder
- keep ProductEditor import from Products folder

## Testing
- `npm run test` *(fails: toastMessage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841e79884bc832ea304a8b1a3e171a9