### PR TITLE
Remove extra Toast from layout

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -36,7 +36,6 @@ const AppLayout: React.FC = () => {
       <main className="flex-1 flex flex-col overflow-y-auto">
         <div className="p-2 md:p-4">
           <Alert />
-          <Toast />
         </div>
         <Toast message={toastMessage} onClose={clearToast} />
         <div className="flex-1 overflow-y-auto">


### PR DESCRIPTION
## Summary
- clean up toast usage in `AppLayout`

## Testing
- `npm test --silent` *(fails: `toastMessage is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_6841e7c54494832eb65fd7f328ae25ff