### PR TITLE
Add toast call after post save

### DIFF
--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -17,6 +17,7 @@ const PostEditor: React.FC = () => {
     setCurrentView,
     addPost,
     updatePost,
+    showToast,
   } = useAppContext();
   
   const [content, setContent] = useState('');
@@ -90,6 +91,7 @@ const PostEditor: React.FC = () => {
           status: 'scheduled'
         });
       }
+      showToast('Публикация сохранена');
       setCurrentView('calendar');
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An error occurred';

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -58,6 +58,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const [role, setRole] = useState<UserRole | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [lastActivity, setLastActivity] = useState<number>(Date.now());
 
   const inactivityMinutes = Number(process.env.VITE_INACTIVITY_TIMEOUT_MINUTES || 0);
@@ -334,6 +335,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   }, [lastActivity, inactivityMs]);
 
   const clearError = () => setError(null);
+  const showToast = (message: string) => setToastMessage(message);
+  const clearToast = () => setToastMessage(null);
 
   return (
     <AppContext.Provider
@@ -365,6 +368,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         signInWithOAuth,
         signOut,
         signOutAll,
+        showToast,
+        clearToast,
         lastActivity,
         clearError,
       }}


### PR DESCRIPTION
## Summary
- show toast when saving post
- restore toast context handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e795f1b8832eabbf47f79d1a650b