### PR TITLE
Fix environment variable lookup

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Calendar, Users, FileText, Lightbulb, Package, LogOut, Loader } from 'lucide-react';
+import { Calendar, Users, FileText, Lightbulb, LogOut, Loader } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import Button from '../ui/Button';
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -61,7 +61,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [lastActivity, setLastActivity] = useState<number>(Date.now());
 
-  const inactivityMinutes = Number(process.env.VITE_INACTIVITY_TIMEOUT_MINUTES || 0);
+  const inactivityMinutes = Number(
+    import.meta.env.VITE_INACTIVITY_TIMEOUT_MINUTES || 0
+  );
   const inactivityMs = inactivityMinutes > 0 ? inactivityMinutes * 60_000 : null;
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- reference `import.meta.env` for inactivity timeout
- clean unused icon import in Sidebar to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841eaa2c164832e9dafb39476e52d67