### PR TITLE
Refactor auth layout

### DIFF
--- a/src/components/Auth/AuthForm.tsx
+++ b/src/components/Auth/AuthForm.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
+
+interface AuthFormProps {
+  email: string;
+  password: string;
+  onEmailChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPasswordChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  loading: boolean;
+  isRegister: boolean;
+  toggleMode: () => void;
+  onForgotPassword: () => void;
+}
+
+const AuthForm: React.FC<AuthFormProps> = ({
+  email,
+  password,
+  onEmailChange,
+  onPasswordChange,
+  onSubmit,
+  loading,
+  isRegister,
+  toggleMode,
+  onForgotPassword,
+}) => (
+  <form onSubmit={onSubmit} className="space-y-4">
+    <div className="relative">
+      <div className="absolute -top-2.5 left-4 px-2 bg-white dark:bg-slate-800">
+        <span className="text-xs text-gray-500">Email</span>
+      </div>
+      <Input
+        type="email"
+        value={email}
+        onChange={onEmailChange}
+        required
+        className="h-12 pl-4 rounded-full border-2"
+        placeholder="chrono@example.com"
+      />
+    </div>
+
+    <div className="relative">
+      <div className="absolute -top-2.5 left-4 px-2 bg-white dark:bg-slate-800">
+        <span className="text-xs text-gray-500">Пароль</span>
+      </div>
+      <div className="absolute -top-2.5 right-4 px-2 bg-white dark:bg-slate-800">
+        <button
+          type="button"
+          className="text-xs text-gray-500 hover:text-gray-700"
+          onClick={onForgotPassword}
+        >
+          Забыли пароль?
+        </button>
+      </div>
+      <Input
+        type="password"
+        value={password}
+        onChange={onPasswordChange}
+        required
+        className="h-12 pl-4 rounded-full border-2"
+      />
+    </div>
+
+    <div className="pt-4 space-y-4">
+      <Button
+        type="submit"
+        disabled={loading}
+        className="w-full h-12 bg-[#222222] hover:bg-[#333333] text-white rounded-full transition-colors"
+      >
+        {isRegister ? 'Зарегистрироваться' : 'Войти'}
+      </Button>
+
+      <div className="text-center space-x-1">
+        <span className="text-gray-500">
+          {isRegister ? 'Уже есть аккаунт?' : 'Нужна учетная запись?'}
+        </span>
+        <button
+          type="button"
+          onClick={toggleMode}
+          className="text-gray-900 dark:text-white font-medium hover:underline"
+        >
+          {isRegister ? 'Войти' : 'Зарегистрироваться'}
+        </button>
+      </div>
+    </div>
+  </form>
+);
+
+export default AuthForm;

--- a/src/components/Auth/AuthLayout.tsx
+++ b/src/components/Auth/AuthLayout.tsx
@@ -1,8 +1,16 @@
 import React, { useState } from 'react';
 import { useAppContext } from '../../context/AppContext';
-import Button from '../ui/Button';
-import Input from '../ui/Input';
+import { getSupabase } from '../../lib/supabase';
 import { Card, CardContent } from '../ui/Card';
+import SocialLoginButtons, { SocialLogin } from './SocialLoginButtons';
+import AuthForm from './AuthForm';
+import ForgotPasswordModal from './ForgotPasswordModal';
+
+const socialLogins: readonly SocialLogin[] = [
+  { name: 'Google', provider: 'google' },
+  { name: 'VK', provider: 'vk' },
+  { name: 'Telegram', provider: 'telegram' },
+] as const;
 
 const AuthLayout: React.FC = () => {
   const { signIn, signUp, signInWithOAuth } = useAppContext();
@@ -11,12 +19,7 @@ const AuthLayout: React.FC = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [isRegister, setIsRegister] = useState(false);
-
-  const socialLogins = [
-    { name: 'Google', provider: 'google' },
-    { name: 'VK', provider: 'vk' },
-    { name: 'Telegram', provider: 'telegram' }
-  ] as const;
+  const [resetOpen, setResetOpen] = useState(false);
 
   const handleOAuth = async (provider: 'telegram' | 'vk' | 'google') => {
     setError('');
@@ -49,6 +52,11 @@ const AuthLayout: React.FC = () => {
     }
   };
 
+  const handleResetPassword = async (resetEmail: string) => {
+    const { error } = await getSupabase().auth.resetPasswordForEmail(resetEmail);
+    if (error) throw error;
+  };
+
   return (
     <div className="min-h-screen bg-[#222222] flex items-center justify-center p-4">
       <Card className="w-full max-w-[480px] rounded-[32px] shadow-xl backdrop-blur-[32px] bg-white dark:bg-slate-800">
@@ -64,84 +72,36 @@ const AuthLayout: React.FC = () => {
           )}
 
           <div className="w-full space-y-6">
-            <div className="space-y-2">
-              {socialLogins.map((social) => (
-                <Button
-                  key={social.provider}
-                  onClick={() => handleOAuth(social.provider)}
-                  disabled={loading}
-                  className="w-full h-12 flex items-center justify-center gap-2 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-full transition-colors"
-                >
-                  <span className="text-gray-700 dark:text-gray-200">
-                    {isRegister ? `Зарегистрироваться через ${social.name}` : `Войти через ${social.name}`}
-                  </span>
-                </Button>
-              ))}
-            </div>
+            <SocialLoginButtons
+              socialLogins={socialLogins}
+              onOAuth={handleOAuth}
+              loading={loading}
+              isRegister={isRegister}
+            />
 
             <div className="text-center text-sm text-gray-500">
               {isRegister ? 'Или зарегистрируйтесь с помощью email' : 'Или войдите с помощью email'}
             </div>
 
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="relative">
-                <div className="absolute -top-2.5 left-4 px-2 bg-white dark:bg-slate-800">
-                  <span className="text-xs text-gray-500">Email</span>
-                </div>
-                <Input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  className="h-12 pl-4 rounded-full border-2"
-                  placeholder="chrono@example.com"
-                />
-              </div>
-
-              <div className="relative">
-                <div className="absolute -top-2.5 left-4 px-2 bg-white dark:bg-slate-800">
-                  <span className="text-xs text-gray-500">Пароль</span>
-                </div>
-                <div className="absolute -top-2.5 right-4 px-2 bg-white dark:bg-slate-800">
-                  <button type="button" className="text-xs text-gray-500 hover:text-gray-700">
-                    Забыли пароль?
-                  </button>
-                </div>
-                <Input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  className="h-12 pl-4 rounded-full border-2"
-                />
-              </div>
-
-              <div className="pt-4 space-y-4">
-                <Button
-                  type="submit"
-                  disabled={loading}
-                  className="w-full h-12 bg-[#222222] hover:bg-[#333333] text-white rounded-full transition-colors"
-                >
-                  {isRegister ? 'Зарегистрироваться' : 'Войти'}
-                </Button>
-
-                <div className="text-center space-x-1">
-                  <span className="text-gray-500">
-                    {isRegister ? 'Уже есть аккаунт?' : 'Нужна учетная запись?'}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => setIsRegister(!isRegister)}
-                    className="text-gray-900 dark:text-white font-medium hover:underline"
-                  >
-                    {isRegister ? 'Войти' : 'Зарегистрироваться'}
-                  </button>
-                </div>
-              </div>
-            </form>
+            <AuthForm
+              email={email}
+              password={password}
+              onEmailChange={(e) => setEmail(e.target.value)}
+              onPasswordChange={(e) => setPassword(e.target.value)}
+              onSubmit={handleSubmit}
+              loading={loading}
+              isRegister={isRegister}
+              toggleMode={() => setIsRegister(!isRegister)}
+              onForgotPassword={() => setResetOpen(true)}
+            />
           </div>
         </CardContent>
       </Card>
+      <ForgotPasswordModal
+        isOpen={resetOpen}
+        onClose={() => setResetOpen(false)}
+        onReset={handleResetPassword}
+      />
     </div>
   );
 };

--- a/src/components/Auth/ForgotPasswordModal.tsx
+++ b/src/components/Auth/ForgotPasswordModal.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
+
+interface ForgotPasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onReset: (email: string) => Promise<void>;
+}
+
+const ForgotPasswordModal: React.FC<ForgotPasswordModalProps> = ({
+  isOpen,
+  onClose,
+  onReset,
+}) => {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await onReset(email);
+      onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+    >
+      <div className="bg-slate-800 rounded-lg w-full max-w-md p-6 relative">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-slate-400 hover:text-white"
+        >
+          ×
+        </button>
+        <h2 className="text-xl font-bold mb-6">Восстановление пароля</h2>
+        {error && (
+          <div className="mb-4 px-4 py-2 bg-red-500/10 border border-red-500 text-red-400 rounded">
+            {error}
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="your@email.com"
+            className="w-full p-3 bg-slate-700 rounded-lg border border-slate-600 focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+          />
+          <div className="flex justify-end space-x-3 pt-2">
+            <Button type="button" onClick={onClose} className="px-4 py-2 bg-slate-700 hover:bg-slate-600">
+              Отмена
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 bg-cyan-600 hover:bg-cyan-500 text-white"
+            >
+              Отправить
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPasswordModal;

--- a/src/components/Auth/SocialLoginButtons.tsx
+++ b/src/components/Auth/SocialLoginButtons.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Button from '../ui/Button';
+
+export interface SocialLogin {
+  name: string;
+  provider: 'telegram' | 'vk' | 'google';
+}
+
+interface SocialLoginButtonsProps {
+  socialLogins: readonly SocialLogin[];
+  onOAuth: (provider: SocialLogin['provider']) => void;
+  loading: boolean;
+  isRegister: boolean;
+}
+
+const SocialLoginButtons: React.FC<SocialLoginButtonsProps> = ({
+  socialLogins,
+  onOAuth,
+  loading,
+  isRegister,
+}) => (
+  <div className="space-y-2">
+    {socialLogins.map((social) => (
+      <Button
+        key={social.provider}
+        onClick={() => onOAuth(social.provider)}
+        disabled={loading}
+        className="w-full h-12 flex items-center justify-center gap-2 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-full transition-colors"
+      >
+        <span className="text-gray-700 dark:text-gray-200">
+          {isRegister
+            ? `Зарегистрироваться через ${social.name}`
+            : `Войти через ${social.name}`}
+        </span>
+      </Button>
+    ))}
+  </div>
+);
+
+export default SocialLoginButtons;


### PR DESCRIPTION
## Summary
- split auth layout into subcomponents
- add modal for password reset
- switch auth logic to new components

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6841f81b962c832e9ff93bb4006a614d