### PR TITLE
Добавлены unit-тесты и тесты API

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -31,6 +31,124 @@ const convertKeys = (
 const toSnake = (obj: unknown): unknown => convertKeys(obj, camelToSnake);
 const toCamel = (obj: unknown): unknown => convertKeys(obj, snakeToCamel);
 
+export const createApp = (supabase: SupabaseClient) => {
+  const app = express();
+  app.use(express.json());
+
+  // Clients endpoints
+  app.get('/api/clients', async (_req, res) => {
+    const { data, error } = await supabase.from('clients').select('*').order('name');
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(toCamel(data));
+  });
+  app.post('/api/clients', async (req, res) => {
+    const payload = toSnake(req.body);
+    const { data, error } = await supabase
+      .from('clients')
+      .insert(payload)
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(toCamel(data));
+  });
+
+  app.put('/api/clients/:id', async (req, res) => {
+    const { id } = req.params;
+    const payload = toSnake(req.body);
+    const { data, error } = await supabase
+      .from('clients')
+      .update(payload)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(toCamel(data));
+  });
+
+  app.delete('/api/clients/:id', async (req, res) => {
+    const { id } = req.params;
+    const { error } = await supabase.from('clients').delete().eq('id', id);
+    if (error) return res.status(500).json({ error: error.message });
+    res.json({ success: true });
+  });
+
+  // Posts endpoints
+  app.get('/api/posts', async (_req, res) => {
+    const { data, error } = await supabase.from('posts').select('*').order('scheduled_for');
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(toCamel(data));
+  });
+
+  app.post('/api/posts', async (req, res) => {
+    const payload = toSnake(req.body);
+    const { data, error } = await supabase
+      .from('posts')
+      .insert(payload)
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(toCamel(data));
+  });
+
+  app.put('/api/posts/:id', async (req, res) => {
+    const { id } = req.params;
+    const payload = toSnake(req.body);
+    const { data, error } = await supabase
+      .from('posts')
+      .update(payload)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(toCamel(data));
+  });
+
+  app.delete('/api/posts/:id', async (req, res) => {
+    const { id } = req.params;
+    const { error } = await supabase.from('posts').delete().eq('id', id);
+    if (error) return res.status(500).json({ error: error.message });
+    res.json({ success: true });
+  });
+
+  // Templates endpoints
+  app.get('/api/templates', async (_req, res) => {
+    const { data, error } = await supabase.from('templates').select('*');
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(data);
+  });
+
+  app.post('/api/templates', async (req, res) => {
+    const { data, error } = await supabase
+      .from('templates')
+      .insert(req.body)
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(data);
+  });
+
+  app.put('/api/templates/:id', async (req, res) => {
+    const { id } = req.params;
+    const { data, error } = await supabase
+      .from('templates')
+      .update(req.body)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(data);
+  });
+
+  app.delete('/api/templates/:id', async (req, res) => {
+    const { id } = req.params;
+    const { error } = await supabase.from('templates').delete().eq('id', id);
+    if (error) return res.status(500).json({ error: error.message });
+    res.json({ success: true });
+  });
+
+  return app;
+};
+
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
 
@@ -40,122 +158,14 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-const app = express();
-app.use(express.json());
-
-// Clients endpoints
-app.get('/api/clients', async (_req, res) => {
-  const { data, error } = await supabase.from('clients').select('*').order('name');
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(toCamel(data));
-});
-
-app.post('/api/clients', async (req, res) => {
-  const payload = toSnake(req.body);
-  const { data, error } = await supabase
-    .from('clients')
-    .insert(payload)
-    .select()
-    .single();
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(toCamel(data));
-});
-
-app.put('/api/clients/:id', async (req, res) => {
-  const { id } = req.params;
-  const payload = toSnake(req.body);
-  const { data, error } = await supabase
-    .from('clients')
-    .update(payload)
-    .eq('id', id)
-    .select()
-    .single();
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(toCamel(data));
-});
-
-app.delete('/api/clients/:id', async (req, res) => {
-  const { id } = req.params;
-  const { error } = await supabase.from('clients').delete().eq('id', id);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json({ success: true });
-});
-
-// Posts endpoints
-app.get('/api/posts', async (_req, res) => {
-  const { data, error } = await supabase.from('posts').select('*').order('scheduled_for');
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(toCamel(data));
-});
-
-app.post('/api/posts', async (req, res) => {
-  const payload = toSnake(req.body);
-  const { data, error } = await supabase
-    .from('posts')
-    .insert(payload)
-    .select()
-    .single();
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(toCamel(data));
-});
-
-app.put('/api/posts/:id', async (req, res) => {
-  const { id } = req.params;
-  const payload = toSnake(req.body);
-  const { data, error } = await supabase
-    .from('posts')
-    .update(payload)
-    .eq('id', id)
-    .select()
-    .single();
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(toCamel(data));
-});
-
-app.delete('/api/posts/:id', async (req, res) => {
-  const { id } = req.params;
-  const { error } = await supabase.from('posts').delete().eq('id', id);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json({ success: true });
-});
-
-// Templates endpoints
-app.get('/api/templates', async (_req, res) => {
-  const { data, error } = await supabase.from('templates').select('*');
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
-});
-
-app.post('/api/templates', async (req, res) => {
-  const { data, error } = await supabase
-    .from('templates')
-    .insert(req.body)
-    .select()
-    .single();
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
-});
-
-app.put('/api/templates/:id', async (req, res) => {
-  const { id } = req.params;
-  const { data, error } = await supabase
-    .from('templates')
-    .update(req.body)
-    .eq('id', id)
-    .select()
-    .single();
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
-});
-
-app.delete('/api/templates/:id', async (req, res) => {
-  const { id } = req.params;
-  const { error } = await supabase.from('templates').delete().eq('id', id);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json({ success: true });
-});
+const app = createApp(supabase);
 
 const PORT = process.env.PORT || 3001;
-app.listen(PORT, () => {
-  console.log(`API server running on port ${PORT}`);
-});
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`API server running on port ${PORT}`);
+  });
+}
+
+export default app;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// @ts-ignore
+global.TextEncoder = TextEncoder as typeof global.TextEncoder;
+// @ts-ignore
+global.TextDecoder = TextDecoder as typeof global.TextDecoder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.35",
+        "supertest": "^7.1.1",
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
@@ -1964,6 +1965,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2000,6 +2014,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3385,6 +3409,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -4248,6 +4279,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4296,6 +4337,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -4745,6 +4793,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/didyoumean": {
@@ -5555,6 +5614,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -5812,6 +5878,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -10505,6 +10589,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
+      "integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.1.tgz",
+      "integrity": "sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.35",
+    "supertest": "^7.1.1",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,94 @@
+import request from 'supertest';
+
+jest.mock('@supabase/supabase-js', () => ({ createClient: jest.fn() }));
+
+process.env.VITE_SUPABASE_URL = 'http://localhost';
+process.env.VITE_SUPABASE_ANON_KEY = 'key';
+
+const { createApp } = jest.requireActual('../../api/index');
+
+/**
+ * @jest-environment node
+ */
+
+describe('Express API', () => {
+  it('GET /api/clients возвращает список клиентов', async () => {
+    const clientsSnake = [
+      { id: '1', name: 'Test', industry: 'IT', color: '#fff', social_accounts: [] }
+    ];
+
+    const mockSupabase = {
+      from: jest.fn(() => ({
+        select: jest.fn().mockReturnValue({
+          order: jest.fn(async () => ({ data: clientsSnake, error: null }))
+        })
+      }))
+    } as unknown as any;
+
+    const app = createApp(mockSupabase);
+
+    const res = await request(app).get('/api/clients');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: '1', name: 'Test', industry: 'IT', color: '#fff', socialAccounts: [] }
+    ]);
+  });
+
+  it('POST /api/posts создает пост', async () => {
+    const postSnake = {
+      id: '1',
+      client_id: 'c1',
+      content: 'hi',
+      platforms: ['telegram'],
+      scheduled_for: '2024-01-01T00:00:00Z',
+      status: 'scheduled',
+      created_at: 'now',
+      updated_at: 'now'
+    };
+
+    const insertMock = jest.fn(() => ({
+      select: jest.fn(() => ({
+        single: jest.fn(async () => ({ data: postSnake, error: null }))
+      }))
+    }));
+
+    const mockSupabase = {
+      from: jest.fn(() => ({ insert: insertMock }))
+    } as unknown as any;
+
+    const app = createApp(mockSupabase);
+    const res = await request(app)
+      .post('/api/posts')
+      .send({
+        clientId: 'c1',
+        content: 'hi',
+        platforms: ['telegram'],
+        scheduledFor: '2024-01-01T00:00:00Z',
+        status: 'scheduled',
+        createdAt: 'now',
+        updatedAt: 'now'
+      });
+
+    expect(insertMock).toHaveBeenCalledWith({
+      client_id: 'c1',
+      content: 'hi',
+      platforms: ['telegram'],
+      scheduled_for: '2024-01-01T00:00:00Z',
+      status: 'scheduled',
+      created_at: 'now',
+      updated_at: 'now'
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: '1',
+      clientId: 'c1',
+      content: 'hi',
+      platforms: ['telegram'],
+      scheduledFor: '2024-01-01T00:00:00Z',
+      status: 'scheduled',
+      createdAt: 'now',
+      updatedAt: 'now'
+    });
+  });
+});

--- a/src/components/Calendar/__tests__/Calendar.test.tsx
+++ b/src/components/Calendar/__tests__/Calendar.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Calendar from '../Calendar';
+import { useAppContext } from '../../../context/AppContext';
+import { Client } from '../../../types';
+
+jest.mock('../../../context/AppContext', () => ({
+  useAppContext: jest.fn()
+}));
+
+const client: Client = {
+  id: 'c1',
+  name: 'Test',
+  industry: 'IT',
+  color: '#fff',
+  socialAccounts: []
+};
+
+const useCtx = useAppContext as jest.MockedFunction<typeof useAppContext>;
+
+const wrapperFactory = () => ({ children }: { children: React.ReactNode }) => (
+  <>{children}</>
+);
+
+describe('Calendar', () => {
+  it('отображает заголовок', () => {
+    useCtx.mockReturnValue({ clients: [client], posts: [] } as any);
+    const wrapper = wrapperFactory();
+    const { getByText } = render(<Calendar />, { wrapper });
+    expect(getByText('Календарь контента')).toBeInTheDocument();
+  });
+
+  it('кнопка добавления поста открывает редактор', () => {
+    const setDate = jest.fn();
+    const setView = jest.fn();
+    useCtx.mockReturnValue({
+      clients: [client],
+      posts: [],
+      role: 'editor',
+      setSelectedDate: setDate,
+      setCurrentView: setView
+    } as any);
+    const wrapper = wrapperFactory();
+    const { getAllByLabelText } = render(<Calendar />, { wrapper });
+    fireEvent.click(getAllByLabelText('Add post')[0]);
+    expect(setDate).toHaveBeenCalledTimes(1);
+    expect(setView).toHaveBeenCalledWith('post-editor');
+  });
+});

--- a/src/components/Posts/PostEditor.tsx
+++ b/src/components/Posts/PostEditor.tsx
@@ -18,6 +18,7 @@ const PostEditor: React.FC = () => {
     addPost,
     updatePost,
     showToast,
+    role,
   } = useAppContext();
   
   const [content, setContent] = useState('');

--- a/src/components/Posts/__tests__/PostEditor.test.tsx
+++ b/src/components/Posts/__tests__/PostEditor.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import PostEditor from '../PostEditor';
+import { useAppContext } from '../../../context/AppContext';
+import { Client } from '../../../types';
+import { formatLocalISO } from '../../../utils/time';
+
+jest.mock('../../../context/AppContext', () => ({
+  useAppContext: jest.fn()
+}));
+jest.mock('../../../lib/storage', () => ({
+  uploadFile: jest.fn()
+}));
+jest.mock('browser-image-compression', () => jest.fn());
+
+const client: Client = {
+  id: 'c1',
+  name: 'Test',
+  industry: 'IT',
+  color: '#fff',
+  socialAccounts: [
+    { id: 's1', platform: 'telegram', handle: '@t', connected: true }
+  ]
+};
+
+const useCtx = useAppContext as jest.MockedFunction<typeof useAppContext>;
+
+const wrapperFactory = () => ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+describe('PostEditor', () => {
+  it('создает новый пост', async () => {
+    const addPost = jest.fn().mockResolvedValue(undefined);
+    const setView = jest.fn();
+    useCtx.mockReturnValue({
+      clients: [client],
+      posts: [],
+      role: 'editor',
+      selectedClient: 'c1',
+      selectedDate: '2024-01-02T00:00:00Z',
+      addPost,
+      updatePost: jest.fn(),
+      setCurrentView: setView,
+      showToast: jest.fn()
+    } as any);
+    const wrapper = wrapperFactory();
+
+    const { getByPlaceholderText, getByText } = render(<PostEditor />, { wrapper });
+
+    fireEvent.change(getByPlaceholderText('Введите текст публикации...'), { target: { value: 'Привет' } });
+
+    await act(async () => {
+      fireEvent.click(getByText('Запланировать'));
+    });
+
+    const scheduled = formatLocalISO(new Date('2024-01-02T12:00:00'));
+    expect(addPost).toHaveBeenCalledWith({
+      content: 'Привет',
+      media: [],
+      clientId: 'c1',
+      platforms: ['telegram'],
+      scheduledFor: scheduled,
+      status: 'scheduled'
+    });
+    expect(setView).toHaveBeenCalledWith('calendar');
+  });
+});


### PR DESCRIPTION
## Summary
- экспорт `createApp` и корректная инициализация Express
- полифилл `TextEncoder` для тестов
- исправлено использование `role` в `PostEditor`
- добавлены unit-тесты компонентов Calendar и PostEditor
- тесты для Express API
- зависимость `supertest` для тестирования API

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841f81ebe44832ea5926f91c5eadf20