### PR TITLE
Add client name and delete confirmation modals

### DIFF
--- a/src/components/Clients/ClientCard.tsx
+++ b/src/components/Clients/ClientCard.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Edit, Trash, Link2 } from 'lucide-react';
 import { Client } from '../../types';
 import { useAppContext } from '../../context/AppContext';
+import EditClientNameModal from './EditClientNameModal';
+import ConfirmModal from './ConfirmModal';
 
 interface ClientCardProps {
   client: Client;
@@ -16,38 +18,37 @@ const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
     role
   } = useAppContext();
 
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
   const handleCreatePost = () => {
     setSelectedClient(client.id);
     setCurrentView('post-editor');
   };
 
-  const handleEdit = async () => {
-    const newName = window.prompt('Новое название клиента', client.name);
-    if (newName && newName !== client.name) {
-      await updateClient(client.id, { name: newName });
-    }
+  const handleEdit = () => {
+    setShowEditModal(true);
   };
 
-  const handleDelete = async () => {
-    if (window.confirm(`Удалить клиента "${client.name}"?`)) {
-      await deleteClient(client.id);
-    }
+  const handleDelete = () => {
+    setShowDeleteModal(true);
   };
 
   return (
-    <div className="bg-slate-800 rounded-lg overflow-hidden border border-slate-700 hover:border-slate-600 transition-colors">
-      <div 
-        className="h-24 bg-gradient-to-r p-3 md:p-4 flex items-end"
-        style={{ 
-          backgroundImage: client.logo 
-            ? `linear-gradient(to right, ${client.color}80, ${client.color}), url(${client.logo})` 
-            : `linear-gradient(to right, ${client.color}50, ${client.color})`,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-        }}
-      >
-        <h3 className="text-xl font-bold text-white">{client.name}</h3>
-      </div>
+    <>
+      <div className="bg-slate-800 rounded-lg overflow-hidden border border-slate-700 hover:border-slate-600 transition-colors">
+        <div
+          className="h-24 bg-gradient-to-r p-3 md:p-4 flex items-end"
+          style={{
+            backgroundImage: client.logo
+              ? `linear-gradient(to right, ${client.color}80, ${client.color}), url(${client.logo})`
+              : `linear-gradient(to right, ${client.color}50, ${client.color})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+          }}
+        >
+          <h3 className="text-xl font-bold text-white">{client.name}</h3>
+        </div>
       
       <div className="p-3 md:p-4">
         <div className="flex items-center text-sm text-slate-400 mb-3">
@@ -105,6 +106,29 @@ const ClientCard: React.FC<ClientCardProps> = ({ client }) => {
         )}
       </div>
     </div>
+    {showEditModal && (
+      <EditClientNameModal
+        initialName={client.name}
+        onClose={() => setShowEditModal(false)}
+        onSave={async name => {
+          if (name && name !== client.name) {
+            await updateClient(client.id, { name });
+          }
+        }}
+      />
+    )}
+    {showDeleteModal && (
+      <ConfirmModal
+        message={`Удалить клиента "${client.name}"?`}
+        confirmText="Удалить"
+        onClose={() => setShowDeleteModal(false)}
+        onConfirm={async () => {
+          await deleteClient(client.id);
+          setShowDeleteModal(false);
+        }}
+      />
+    )}
+    </>
   );
 };
 

--- a/src/components/Clients/ConfirmModal.tsx
+++ b/src/components/Clients/ConfirmModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface ConfirmModalProps {
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => Promise<void> | void;
+  onClose: () => void;
+}
+
+const ConfirmModal: React.FC<ConfirmModalProps> = ({
+  message,
+  confirmText = 'Подтвердить',
+  cancelText = 'Отмена',
+  onConfirm,
+  onClose
+}) => (
+  <div role="dialog" aria-modal="true" className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="bg-slate-800 rounded-lg w-full max-w-sm p-6">
+      <p className="mb-6">{message}</p>
+      <div className="flex justify-end space-x-3">
+        <button type="button" onClick={onClose} className="px-4 py-2 bg-slate-700 rounded-lg hover:bg-slate-600 transition-colors">
+          {cancelText}
+        </button>
+        <button type="button" onClick={onConfirm} className="px-4 py-2 bg-red-600 rounded-lg hover:bg-red-500 transition-colors">
+          {confirmText}
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default ConfirmModal;

--- a/src/components/Clients/EditClientNameModal.tsx
+++ b/src/components/Clients/EditClientNameModal.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface EditClientNameModalProps {
+  initialName: string;
+  onSave: (name: string) => Promise<void>;
+  onClose: () => void;
+}
+
+const EditClientNameModal: React.FC<EditClientNameModalProps> = ({ initialName, onSave, onClose }) => {
+  const [name, setName] = useState(initialName);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await onSave(name.trim());
+      onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-slate-800 rounded-lg w-full max-w-sm p-6 relative">
+        <button onClick={onClose} className="absolute top-4 right-4 text-slate-400 hover:text-white">
+          <X size={20} />
+        </button>
+        <h2 className="text-xl font-bold mb-6">Изменить название клиента</h2>
+        {error && (
+          <div className="mb-4 px-4 py-2 bg-red-500/10 border border-red-500 text-red-400 rounded">
+            {error}
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            required
+            className="w-full p-3 bg-slate-700 rounded-lg border border-slate-600 focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+          />
+          <div className="flex justify-end space-x-3 pt-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 bg-slate-700 rounded-lg hover:bg-slate-600 transition-colors">
+              Отмена
+            </button>
+            <button type="submit" disabled={loading} className="px-4 py-2 bg-cyan-600 rounded-lg hover:bg-cyan-500 disabled:opacity-50 transition-colors">
+              Сохранить
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EditClientNameModal;


### PR DESCRIPTION
## Summary
- add `EditClientNameModal` component
- add `ConfirmModal` component
- use these modals in `ClientCard` instead of `window.prompt` and `window.confirm`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f9b7800c832e853dd308f4f4f210